### PR TITLE
Py 2.7/3.6 compatible, enable travis, Sphinx >= 1.4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.idea/
+.venv/
+sphinxcontrib/__pycache__/
+sphinxcontrib_matlabdomain.egg-info/
+tests/__pycache__/
+.tox/
+tests/test_docs/_build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+  - "3.6"
+install:
+  - pip install tox
+script:
+  - tox

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst', 'r') as f_readme:
 
 version = '0.2.8'
 
-requires = ['Sphinx>=1.4.3', 'Pygments>=2.0.1']
+requires = ['Sphinx>=1.4.3', 'Pygments>=2.0.1', 'future>=0.16.0']
 
 setup(
     name='sphinxcontrib-matlabdomain',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst', 'r') as f_readme:
 
 version = '0.2.8'
 
-requires = ['Sphinx>=1.2', 'Pygments>=2.0.1']
+requires = ['Sphinx>=1.4.3', 'Pygments>=2.0.1']
 
 setup(
     name='sphinxcontrib-matlabdomain',

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -9,7 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 from __future__ import unicode_literals
-from builtins import dict
+from builtins import *
 import re
 import sys
 import inspect

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -8,7 +8,7 @@
     :copyright: Copyright 2014 Mark Mikofski
     :license: BSD, see LICENSE for details.
 """
-
+from __future__ import unicode_literals
 import re
 import sys
 import inspect
@@ -56,7 +56,7 @@ mat_ext_sig_re = re.compile(
           )? $                          # and nothing more
           ''', re.VERBOSE)
 
-from mat_types import *
+from .mat_types import *
 # import MatObject, MatModule, MatFunction, MatClass, MatProperty, MatMethod,
 # MatScript, MatException, MatModuleAnalyzer
 
@@ -158,12 +158,11 @@ class MatlabDocumenter(PyDocumenter):
         # set sourcename and add content from attribute documentation
         if self.analyzer:
             # prevent encoding errors when the file name is non-ASCII
-            if not isinstance(self.analyzer.srcname, unicode):
-                filename = unicode(self.analyzer.srcname,
-                                   sys.getfilesystemencoding(), 'replace')
+            if not isinstance(self.analyzer.srcname, str):
+                filename = str(self.analyzer.srcname)
             else:
                 filename = self.analyzer.srcname
-            sourcename = u'%s:docstring of %s' % (filename, self.fullname)
+            sourcename = '%s:docstring of %s' % (filename, self.fullname)
 
             attr_docs = self.analyzer.find_attr_docs()
             if self.objpath:
@@ -174,7 +173,7 @@ class MatlabDocumenter(PyDocumenter):
                     for i, line in enumerate(self.process_doc(docstrings)):
                         self.add_line(line, sourcename, i)
         else:
-            sourcename = u'docstring of %s' % self.fullname
+            sourcename = 'docstring of %s' % self.fullname
 
         # add content from docstrings
         if not no_docstring:
@@ -204,7 +203,7 @@ class MatlabDocumenter(PyDocumenter):
         if self.analyzer:
             attr_docs = self.analyzer.find_attr_docs()
             namespace = '.'.join(self.objpath)
-            for item in attr_docs.iteritems():
+            for item in attr_docs.items():
                 if item[0][0] == namespace:
                     analyzed_member_names.add(item[0][1])
         if not want_all:
@@ -235,7 +234,7 @@ class MatlabDocumenter(PyDocumenter):
                 members = []
             else:
                 members = [(mname, self.get_attr(self.object, mname, None))
-                           for mname in obj_dict.keys()]
+                           for mname in list(obj_dict.keys())]
         membernames = set(m[0] for m in members)
         # add instance attributes from the analyzer
         for aname in analyzed_member_names:
@@ -345,7 +344,7 @@ class MatlabDocumenter(PyDocumenter):
         # document non-skipped members
         memberdocumenters = []
         for (mname, member, isattr) in self.filter_members(members, want_all):
-            classes = [cls for cls in AutoDirective._registry.itervalues()
+            classes = [cls for cls in AutoDirective._registry.values()
                        if cls.can_document_member(member, mname, isattr, self)]
             if not classes:
                 # don't know how to document this member
@@ -417,7 +416,7 @@ class MatlabDocumenter(PyDocumenter):
             # parse right now, to get PycodeErrors on parsing (results will
             # be cached anyway)
             self.analyzer.find_attr_docs()
-        except PycodeError, err:
+        except PycodeError as err:
             self.env.app.debug('[autodoc] module analyzer failed: %s', err)
             # no source file -- e.g. for builtin and C modules
             self.analyzer = None
@@ -435,14 +434,14 @@ class MatlabDocumenter(PyDocumenter):
         # make sure that the result starts with an empty line.  This is
         # necessary for some situations where another directive preprocesses
         # reST and no starting newline is present
-        self.add_line(u'', '<autodoc>')
+        self.add_line('', '<autodoc>')
 
         # format the object's signature, if any
         sig = self.format_signature()
 
         # generate the directive header and options, if applicable
         self.add_directive_header(sig)
-        self.add_line(u'', '<autodoc>')
+        self.add_line('', '<autodoc>')
 
         # e.g. the module directive doesn't have content
         self.indent += self.content_indent
@@ -469,12 +468,12 @@ class MatModuleDocumenter(MatlabDocumenter, PyModuleDocumenter):
         # add some module-specific options
         if self.options.synopsis:
             self.add_line(
-                u'   :synopsis: ' + self.options.synopsis, '<autodoc>')
+                '   :synopsis: ' + self.options.synopsis, '<autodoc>')
         if self.options.platform:
             self.add_line(
-                u'   :platform: ' + self.options.platform, '<autodoc>')
+                '   :platform: ' + self.options.platform, '<autodoc>')
         if self.options.deprecated:
-            self.add_line(u'   :deprecated:', '<autodoc>')
+            self.add_line('   :deprecated:', '<autodoc>')
 
     def get_object_members(self, want_all):
         if want_all:
@@ -698,12 +697,12 @@ class MatClassDocumenter(MatModuleLevelDocumenter):
 
         # add inheritance info, if wanted
         if not self.doc_as_attr and self.options.show_inheritance:
-            self.add_line(u'', '<autodoc>')
+            self.add_line('', '<autodoc>')
             if len(self.object.__bases__):
-                bases = [not v and u':class:`%s`' % b or
-                         u':class:`%s.%s`' % (v.__module__, b)
-                         for b, v in self.object.__bases__.iteritems()]
-                self.add_line(_(u'   Bases: %s') % ', '.join(bases),
+                bases = [not v and ':class:`%s`' % b or
+                         ':class:`%s.%s`' % (v.__module__, b)
+                         for b, v in self.object.__bases__.items()]
+                self.add_line(_('   Bases: %s') % ', '.join(bases),
                               '<autodoc>')
 
     def get_doc(self, encoding=None, ignore=1):
@@ -741,7 +740,7 @@ class MatClassDocumenter(MatModuleLevelDocumenter):
                     docstrings.append(initdocstring)
         doc = []
         for docstring in docstrings:
-            if not isinstance(docstring, unicode):
+            if not isinstance(docstring, str):
                 docstring = force_decode(docstring, encoding)
             doc.append(prepare_docstring(docstring))
         return doc
@@ -857,11 +856,11 @@ class MatAttributeDocumenter(MatClassLevelDocumenter):
                 except ValueError:
                     pass
                 else:
-                    self.add_line(u'   :annotation: = ' + objrepr, '<autodoc>')
+                    self.add_line('   :annotation: = ' + objrepr, '<autodoc>')
         elif self.options.annotation is SUPPRESS:
             pass
         else:
-            self.add_line(u'   :annotation: %s' % self.options.annotation,
+            self.add_line('   :annotation: %s' % self.options.annotation,
                           '<autodoc>')
 
     def add_content(self, more_content, no_docstring=False):

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 from __future__ import unicode_literals
+from builtins import dict
 import re
 import sys
 import inspect

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -9,7 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 from __future__ import unicode_literals, print_function
-from builtins import dict
+from builtins import *
 import os
 import re
 import sys

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -8,7 +8,7 @@
     :copyright: Copyright 2014 Mark Mikofski
     :license: BSD, see LICENSE for details.
 """
-
+from __future__ import unicode_literals, print_function
 import os
 import re
 import sys
@@ -56,7 +56,7 @@ class MatObject(object):
         """
         Alternate for sphinx_dbg for test-mode.
         """
-        print '\t<test-mode>\n' + msg % args
+        print('\t<test-mode>\n' + msg % args)
 
     basedir = None
     sphinx_env = None
@@ -225,7 +225,7 @@ class MatModule(MatObject):
             # trim file extension
             if os.path.isfile(path):
                 key, _ = os.path.splitext(key)
-            if not results or key not in zip(*results)[0]:
+            if not results or key not in list(zip(*results))[0]:
                 value = self.getter(key, None)
                 if value:
                     results.append((key, value))
@@ -240,7 +240,7 @@ class MatModule(MatObject):
     def __all__(self):
         results = self.safe_getmembers
         if results:
-            results = zip(*self.safe_getmembers)[0]
+            results = list(zip(*self.safe_getmembers))[0]
         return results
 
     @property
@@ -378,8 +378,8 @@ class MatFunction(MatObject):
     :type tokens: list
     """
     # MATLAB keywords that increment keyword-end pair count
-    mat_kws = zip((Token.Keyword,) * 5,
-                  ('if', 'while', 'for', 'switch', 'try'))
+    mat_kws = list(zip((Token.Keyword,) * 5,
+                  ('if', 'while', 'for', 'switch', 'try')))
 
     def __init__(self, name, modname, tokens):
         super(MatFunction, self).__init__(name)
@@ -488,7 +488,7 @@ class MatFunction(MatObject):
                 wht = tks.pop()  # skip whitespace
             except IndexError:
                 break
-            while wht in zip((Token.Text,) * 3, (' ', '\t', '\n')):
+            while wht in list(zip((Token.Text,) * 3, (' ', '\t', '\n'))):
                 try:
                     wht = tks.pop()
                 except IndexError:
@@ -512,9 +512,9 @@ class MatFunction(MatObject):
             elif kw == (Token.Keyword, 'end') and not lastkw:
                 kw_end -= 1
             # save last punctuation
-            elif kw in zip((Token.Punctuation,) * 2, ('(', '{')):
+            elif kw in list(zip((Token.Punctuation,) * 2, ('(', '{'))):
                 lastkw += 1
-            elif kw in zip((Token.Punctuation,) * 2, (')', '}')):
+            elif kw in list(zip((Token.Punctuation,) * 2, (')', '}'))):
                 lastkw -= 1
             try:
                 kw = tks.pop()
@@ -527,7 +527,7 @@ class MatFunction(MatObject):
 
     @property
     def __doc__(self):
-        return unicode(self.docstring)
+        return str(self.docstring)
 
     @property
     def __module__(self):
@@ -733,12 +733,12 @@ class MatClass(MatMixin, MatObject):
                                 self.tokens[idx][1].startswith('...'))):
                             token = self.tokens[idx]
                             # default has an array spanning multiple lines
-                            if (token in zip((Token.Punctuation,) * 3,
-                                ('(', '{', '['))):
+                            if (token in list(zip((Token.Punctuation,) * 3,
+                                ('(', '{', '[')))):
                                 punc_ctr += 1  # increment punctuation counter
                             # look for end of array
-                            elif (token in zip((Token.Punctuation,) * 3,
-                                       (')', '}', ']'))):
+                            elif (token in list(zip((Token.Punctuation,) * 3,
+                                       (')', '}', ']')))):
                                 punc_ctr -= 1  # decrement punctuation counter
                             # Pygments treats continuation ellipsis as comments
                             # text from ellipsis until newline is in token
@@ -900,7 +900,7 @@ class MatClass(MatMixin, MatObject):
 
     @property
     def __doc__(self):
-        return unicode(self.docstring)
+        return str(self.docstring)
 
     @property
     def __bases__(self):
@@ -958,7 +958,7 @@ class MatClass(MatMixin, MatObject):
             return self.methods[name]
         elif name == '__dict__':
             objdict = dict([(pn, self.getter(pn)) for pn in
-                            self.properties.iterkeys()])
+                            self.properties.keys()])
             objdict.update(self.methods)
             return objdict
         else:
@@ -975,7 +975,7 @@ class MatProperty(MatObject):
 
     @property
     def __doc__(self):
-        return unicode(self.docstring)
+        return str(self.docstring)
 
 
 class MatMethod(MatFunction):
@@ -998,7 +998,7 @@ class MatMethod(MatFunction):
 
     @property
     def __doc__(self):
-        return unicode(self.docstring)
+        return str(self.docstring)
 
 
 class MatScript(MatObject):
@@ -1010,7 +1010,7 @@ class MatScript(MatObject):
 
     @property
     def __doc__(self):
-        return unicode(self.docstring)
+        return str(self.docstring)
 
 
 class MatException(MatObject):
@@ -1022,7 +1022,7 @@ class MatException(MatObject):
 
     @property
     def __doc__(self):
-        return unicode(self.docstring)
+        return str(self.docstring)
 
 
 class MatcodeError(Exception):
@@ -1097,7 +1097,7 @@ class MatModuleAnalyzer(object):
                 attr_visitor_tagorder[k] = tagnumber
                 tagnumber += 1
             if isinstance(v, MatClass):
-                for mk, mv in v.getter('__dict__').iteritems():
+                for mk, mv in v.getter('__dict__').items():
                     namespace = '.'.join([mod.package, k])
                     attr_visitor_collected[namespace, mk] = mv.docstring
                     attr_visitor_tagorder[mk] = tagnumber

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 from __future__ import unicode_literals, print_function
+from builtins import dict
 import os
 import re
 import sys

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -8,8 +8,8 @@
     :copyright: Copyright 2007-2011 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-
-import mat_documenters as doc
+from __future__ import absolute_import, unicode_literals
+from . import mat_documenters as doc
 
 import re
 
@@ -229,8 +229,8 @@ class MatObject(ObjectDescription):
 
         indextext = self.get_index_text(modname, name_cls)
         if indextext:
-            self.indexnode['entries'].append(('single', indextext,
-                                              fullname, ''))
+            entry = ('single', indextext, fullname, '', None)
+            self.indexnode['entries'].append(entry)
 
     def before_content(self):
         # needed for automatic qualification of members (reset in subclasses)
@@ -434,8 +434,8 @@ class MatModule(Directive):
             # used in the modindex currently
             ret.append(targetnode)
             indextext = _('%s (module)') % modname
-            inode = addnodes.index(entries=[('single', indextext,
-                                             'module-' + modname, '')])
+            entry = ('single', indextext, 'module-' + modname, '', None)
+            inode = addnodes.index(entries=[entry])
             ret.append(inode)
         return ret
 
@@ -499,7 +499,7 @@ class MATLABModuleIndex(Index):
         ignores = self.domain.env.config['modindex_common_prefix']
         ignores = sorted(ignores, key=len, reverse=True)
         # list of all modules, sorted by module name
-        modules = sorted(self.domain.data['modules'].iteritems(),
+        modules = sorted(iter(self.domain.data['modules'].items()),
                          key=lambda x: x[0].lower())
         # sort out collapsable modules
         prev_modname = ''
@@ -549,7 +549,7 @@ class MATLABModuleIndex(Index):
         collapse = len(modules) - num_toplevels < num_toplevels
 
         # sort by first letter
-        content = sorted(content.iteritems())
+        content = sorted(content.items())
 
         return content, collapse
 
@@ -604,10 +604,10 @@ class MATLABDomain(Domain):
     ]
 
     def clear_doc(self, docname):
-        for fullname, (fn, _) in self.data['objects'].items():
+        for fullname, (fn, _) in list(self.data['objects'].items()):
             if fn == docname:
                 del self.data['objects'][fullname]
-        for modname, (fn, _, _, _) in self.data['modules'].items():
+        for modname, (fn, _, _, _) in list(self.data['modules'].items()):
             if fn == docname:
                 del self.data['modules'][modname]
 
@@ -705,9 +705,9 @@ class MATLABDomain(Domain):
                                 contnode, name)
 
     def get_objects(self):
-        for modname, info in self.data['modules'].iteritems():
+        for modname, info in self.data['modules'].items():
             yield (modname, modname, 'module', info[0], 'module-' + modname, 0)
-        for refname, (docname, type) in self.data['objects'].iteritems():
+        for refname, (docname, type) in self.data['objects'].items():
             yield (refname, refname, type, docname, refname, 1)
 
 def setup(app):

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -9,7 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 from __future__ import absolute_import, unicode_literals
-from builtins import dict
+from builtins import *
 from . import mat_documenters as doc
 
 import re

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 from __future__ import absolute_import, unicode_literals
+from builtins import dict
 from . import mat_documenters as doc
 
 import re

--- a/tests/test_docs/conf.py
+++ b/tests/test_docs/conf.py
@@ -11,7 +11,7 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
+from __future__ import unicode_literals
 import sys
 import os
 
@@ -45,8 +45,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'MATLAB Sphinx Documentation Test'
-copyright = u'2014, Mark Mikofski'
+project = 'MATLAB Sphinx Documentation Test'
+copyright = '2014, Mark Mikofski'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -198,8 +198,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'MATLABSphinxDocumentationTest.tex', u'MATLAB Sphinx Documentation Test Documentation',
-   u'Mark Mikofski', 'manual'),
+  ('index', 'MATLABSphinxDocumentationTest.tex', 'MATLAB Sphinx Documentation Test Documentation',
+   'Mark Mikofski', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -228,8 +228,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'matlabsphinxdocumentationtest', u'MATLAB Sphinx Documentation Test Documentation',
-     [u'Mark Mikofski'], 1)
+    ('index', 'matlabsphinxdocumentationtest', 'MATLAB Sphinx Documentation Test Documentation',
+     ['Mark Mikofski'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -242,8 +242,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'MATLABSphinxDocumentationTest', u'MATLAB Sphinx Documentation Test Documentation',
-   u'Mark Mikofski', 'MATLABSphinxDocumentationTest', 'One line description of project.',
+  ('index', 'MATLABSphinxDocumentationTest', 'MATLAB Sphinx Documentation Test Documentation',
+   'Mark Mikofski', 'MATLABSphinxDocumentationTest', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/tests/test_mat_types.py
+++ b/tests/test_mat_types.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+from __future__ import print_function
 
 from sphinxcontrib import mat_documenters as doc
 from nose.tools import eq_, ok_
@@ -115,33 +116,33 @@ def test_property_with_ellipsis():
 
 if __name__ == '__main__':
     f1 = test_ellipsis_after_equals
-    print f1.__name__
-    print f1.__module__
-    print f1.__doc__
+    print(f1.__name__)
+    print(f1.__module__)
+    print(f1.__doc__)
     f2 = test_no_args()
-    print f2.__name__
-    print f2.__module__
-    print f2.__doc__
+    print(f2.__name__)
+    print(f2.__module__)
+    print(f2.__doc__)
     f3 = test_no_outputs()
-    print f3.__name__
-    print f3.__module__
-    print f3.__doc__
+    print(f3.__name__)
+    print(f3.__module__)
+    print(f3.__doc__)
     f4 = test_output_with_ellipsis()
-    print f4.__name__
-    print f4.__module__
-    print f4.__doc__
+    print(f4.__name__)
+    print(f4.__module__)
+    print(f4.__doc__)
     f5 = test_output_without_commas()
-    print f5.__name__
-    print f5.__module__
-    print f5.__doc__
+    print(f5.__name__)
+    print(f5.__module__)
+    print(f5.__doc__)
     sfdm = test_inheritance()
-    print sfdm.__name__
-    print sfdm.__module__
-    print sfdm.__doc__
+    print(sfdm.__name__)
+    print(sfdm.__module__)
+    print(sfdm.__doc__)
     ep, A, B, C = test_property_with_ellipsis()
-    print ep.__name__
-    print ep.__module__
-    print ep.__doc__
+    print(ep.__name__)
+    print(ep.__module__)
+    print(ep.__doc__)
     pprint(A.__dict__)
     pprint(B.__dict__)
     pprint(C.__dict__)

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-
+from __future__ import print_function
 from sphinxcontrib import mat_documenters as doc
 from nose.tools import eq_, ok_
 import json
@@ -38,7 +38,7 @@ def test_matlabify_class():
     ok_(isinstance(my_abc, doc.MatClass))
     eq_(my_abc.getter('__name__'), 'MyAbstractClass')
     eq_(my_abc.getter('__module__'), 'test_data')
-    eq_(my_abc.bases, [u'MyHandleClass', 'MyClass'])
+    eq_(my_abc.bases, ['MyHandleClass', 'MyClass'])
     eq_(my_abc.attrs, {'Abstract': True, 'Sealed': True})
     eq_(my_abc.properties,
         {'y': {'default': None,
@@ -89,46 +89,46 @@ def test_method():
 if __name__ == '__main__':
     m, my_cls, x, my_abc, y, version = test_matlabify_class()
 
-    print '\nmodule: %s' % m
-    print 'docstring:\n%s' % m.getter('__doc__')
+    print('\nmodule: %s' % m)
+    print('docstring:\n%s' % m.getter('__doc__'))
    
-    print '\nclass: %s' % my_cls
-    print 'bases: %s' % my_cls.bases
-    print 'class attributes: %s' % my_cls.attrs
-    print 'properties:\n'
-    print json.dumps(my_cls.properties, indent=2, sort_keys=True)
-    print 'docstring:\n%s' % my_cls.getter('__doc__')
+    print('\nclass: %s' % my_cls)
+    print('bases: %s' % my_cls.bases)
+    print('class attributes: %s' % my_cls.attrs)
+    print('properties:\n')
+    print(json.dumps(my_cls.properties, indent=2, sort_keys=True))
+    print('docstring:\n%s' % my_cls.getter('__doc__'))
 
-    print '\nx property: %s' % x
-    print 'x default: %s' % x.default
-    print 'x docstring: %s' % x.__doc__
-    print 'x attrs: %s' % x.attrs
+    print('\nx property: %s' % x)
+    print('x default: %s' % x.default)
+    print('x docstring: %s' % x.__doc__)
+    print('x attrs: %s' % x.attrs)
    
-    print '\nclass: %s' % my_abc
-    print 'bases: %s' % my_abc.bases
-    print 'class attributes: %s' % my_abc.attrs
-    print 'properties:\n'
-    print json.dumps(my_abc.properties, indent=2, sort_keys=True)
-    print 'docstring:\n%s' % my_abc.docstring
+    print('\nclass: %s' % my_abc)
+    print('bases: %s' % my_abc.bases)
+    print('class attributes: %s' % my_abc.attrs)
+    print('properties:\n')
+    print(json.dumps(my_abc.properties, indent=2, sort_keys=True))
+    print('docstring:\n%s' % my_abc.docstring)
 
-    print '\ny property: %s' % y
-    print 'y docstring: %s' % y.__doc__
-    print 'y default: %s' % y.default
-    print 'y attrs: %s' % y.attrs
-    print 'version property: %s' % version
-    print 'version default: %s' % version.default
-    print 'version docstring: %s' % version.__doc__
-    print 'version attrs: %s' % version.attrs
-    print '\n'
+    print('\ny property: %s' % y)
+    print('y docstring: %s' % y.__doc__)
+    print('y default: %s' % y.default)
+    print('y attrs: %s' % y.attrs)
+    print('version property: %s' % version)
+    print('version default: %s' % version.default)
+    print('version docstring: %s' % version.__doc__)
+    print('version attrs: %s' % version.attrs)
+    print('\n')
 
     myfun = test_function()
-    print 'function: %s' % myfun
-    print 'returns: %s' % myfun.retv
-    print 'name: %s' % myfun.getter('__name__')
-    print 'args: %s' % myfun.args
-    print 'docstring:\n%s' % myfun.getter('__doc__')
+    print('function: %s' % myfun)
+    print('returns: %s' % myfun.retv)
+    print('name: %s' % myfun.getter('__name__'))
+    print('args: %s' % myfun.args)
+    print('docstring:\n%s' % myfun.getter('__doc__'))
 
     my_cls_meth, constructor, mymethod = test_method()
-    print my_cls_meth
-    print constructor
-    print mymethod
+    print(my_cls_meth)
+    print(constructor)
+    print(mymethod)

--- a/tox.ini
+++ b/tox.ini
@@ -4,29 +4,19 @@
 ## tox configuration outlines a basic setup for running unit tests and
 ## building sphinx docs in separate virtual environments.  Give it a try!
 
-[tox]
-envlist=python,doc
-
 # test running
-[testenv:python]
-deps=
-    ## if you use nose for test running
-    # nose
-    ## if you use py.test for test running
-    # pytest
-commands=
-    ## run tests with py.test
-    # py.test []
-    ## run tests with nose
-    # nose
+[testenv]
+deps =
+    nose
+    pytest
+commands =
+    pytest
 
 [testenv:doc]
-deps=
-    sphinx
-    # add all Sphinx extensions and other dependencies required to build your docs
+changedir=tests/test_docs
+deps= sphinx
 commands=
-    ## test links
-    # sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees doc {envtmpdir}/linkcheck
-    ## test html output
-    # sphinx-build -W -b html -d {envtmpdir}/doctrees doc {envtmpdir}/html
-
+;    ## test links
+;    #sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees doc {envtmpdir}/linkcheck
+;    ## test html output
+    sphinx-build -M html . _build


### PR DESCRIPTION
- I ran 2to3.py and added from __future__ imports. So now its Python 2.7 and 3.6 compatible
- Setup travis to run the tests and generate html from the docs.
- Fixed the Sphinx <1.4.3 warning on "WARNING: 4 column based index found"
- Issues:
  - Still has warnings like "WARNING: while setting up extension sphinxcontrib.matlab: directive 'automodule' is already registered, it will be overridden"
