### PR TITLE
Bug fix for issue #58, when a Matlab-file has some comment lines at the top.

### DIFF
--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -153,6 +153,8 @@ class MatObject(object):
         # read mfile code
         with open(mfile, 'r') as code_f:
             code = code_f.read().replace('\r\n', '\n')  # repl crlf with lf
+        # remove the top comment header (if there is one) from the code string
+        code = MatObject._remove_comment_header(code)
         # functions must be contained in one line, no ellipsis, classdef is OK
         pat = r"^([^%\n]*)(\.\.\..*\n)"
         code = re.sub(pat, '\g<1>', code, flags=re.MULTILINE)
@@ -188,6 +190,30 @@ class MatObject(object):
             # it's a script file
             return MatScript(name, modname, tks)
         return None
+
+    @staticmethod
+    def _remove_comment_header(code):
+        """
+        Removes the comment header (if there is one) and empty lines from the
+        top of the current read code.
+        :param code: Current code string.
+        :type code: str
+        :returns: Code string without comments above a function, class or
+                  procedure/script.
+        """
+        # get the line number when the comment header ends (incl. empty lines)
+        ln_pos = 0
+        for line in code.splitlines(1):
+            if re.match(r"[ \t]*(%|\n)", line):
+                ln_pos += 1
+            else:
+                break
+
+        if ln_pos > 0:
+            # remove the header block and empty lines from the top of the code
+            code = code.split('\n', ln_pos)[ln_pos:][0]
+
+        return code
 
 
 # TODO: get docstring and __all__ from contents.m if exists
@@ -836,7 +862,7 @@ class MatClass(MatMixin, MatObject):
                         idx += 1 + self._whitespace(idx + 1)
                     elif self._tk_eq(idx, (Token.Keyword, 'end')):
                         idx += 1
-                        break 
+                        break
                     else:
                         # find methods
                         meth = MatMethod(self.module, self.tokens[idx:],

--- a/tests/test_data/ClassWithCommentHeader.m
+++ b/tests/test_data/ClassWithCommentHeader.m
@@ -1,0 +1,48 @@
+% This is a Comment Header
+% Copyright (C) <year>, by <full_name>
+%
+% Some descriptions ...
+%
+% This header and all further comments above the class
+% will be ignored by the documentation system.
+%
+% Lisence (GPL, BSD, etc.)
+%
+
+  % a comment with space indentation ...
+
+    % a comment with tab indentation ...
+
+classdef ClassWithCommentHeader
+    % A class with a comment header on the top.
+
+    properties
+        link_name = 'none';     % name of the reference link
+        pos       = zeros(3,1); % Cartesian position of the link
+        rotm      = eye(3,3);   % (3 x 3) rotation matrix
+        idx       = 0;          % index of the reference link
+    end
+
+    methods
+        function obj = ClassWithCommentHeader(link_name, pos, rotm)
+            % Constructor.
+            %
+            % :param link_name: Name of the reference link.
+            % :param pos:       Cartesian position of the link.
+            % :param rotm:      (3 x 3) rotation matrix.
+            obj.link_name = link_name;
+            obj.pos       = pos;
+            obj.rotm      = rotm;
+        end
+
+        function tform = getTransformation(obj)
+            % A transformation method in :class:`ClassWithCommentHeader`.
+            %
+            % :returns: ``tform``, a (4 x 4) homogeneous transformation matrix.
+            tform = eye(4,4);
+            tform(1:3,1:3) = obj.rotm;
+            tform(1:3,4)   = obj.pos;
+        end
+
+    end
+end

--- a/tests/test_data/f_with_comment_header.m
+++ b/tests/test_data/f_with_comment_header.m
@@ -1,0 +1,33 @@
+% This is a Comment Header
+% Copyright (C) <year>, by <full_name>
+%
+% Some descriptions ...
+%
+% This header and all further comments above the function
+% will be ignored by the documentation system.
+%
+% Lisence (GPL, BSD, etc.)
+%
+
+  % a comment with space indentation ...
+
+    % a comment with tab indentation ...
+
+function [o1, o2, o3] = f_with_comment_header(a1, a2)
+    % A simple function with a comment header on the top.
+
+    % Check input args
+    if (nargin < 1)
+      a1 = 0;
+    end
+    if (nargin < 2)
+      a2 = a1;
+    end
+    o1 = a1; o2 = a2; o3 = a1 + a2;
+
+    for n = 1:3
+        o1 = o2;
+        o2 = o3;
+        o3 = o1 + o2;
+    end
+end

--- a/tests/test_data/script_with_comment_header.m
+++ b/tests/test_data/script_with_comment_header.m
@@ -1,0 +1,17 @@
+% This is a Comment Header
+% Copyright (C) <year>, by <full_name>
+%
+% Some descriptions ...
+%
+% This header and all further comments above the first command line
+% of the script will be ignored by the documentation system.
+%
+% Lisence (GPL, BSD, etc.)
+%
+
+  % a comment with space indentation ...
+
+    % a comment with tab indentation ...
+
+% This comment line will be also ignored by the documentation system.
+[o1, o2, o3] = f_example(10, 31); % A script calling other functions

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -41,7 +41,8 @@ def test_module(mod):
                           'ClassInheritHandle', 'ClassWithEllipsisProperties',
                           'ClassWithEndOfLineComment', 'f_example', 'f_with_nested_function',
                           'submodule', 'script', 'Bool', 'ClassWithEvent',
-                          'f_no_input_no_output_no_parentheses'))
+                          'f_no_input_no_output_no_parentheses', 'ClassWithCommentHeader',
+                          'f_with_comment_header', 'script_with_comment_header'))
     assert all_items == expected_items
     assert mod.getter('__name__') in sys.modules
 

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -96,7 +96,6 @@ def test_no_docstring():
     assert obj.docstring == ''
 
 
-
 def test_no_output():
     mfile = os.path.join(TESTDATA_SUB, 'f_no_output.m')
     obj = mat_types.MatObject.parse_mfile(mfile, 'f_no_output', '')
@@ -161,6 +160,30 @@ def test_no_input_no_output_no_parentheses():
     obj = mat_types.MatObject.parse_mfile(mfile, 'f_no_input_no_output_no_parentheses', 'test_data')
     assert obj.name == 'f_no_input_no_output_no_parentheses'
     assert obj.docstring == " Tests a function without parentheses in input and no return value\n"
+
+
+def test_ClassWithCommentHeader():
+    mfile = os.path.join(DIRNAME, 'test_data', 'ClassWithCommentHeader.m')
+    obj = mat_types.MatObject.parse_mfile(mfile, 'ClassWithCommentHeader', 'test_data')
+    assert obj.name == 'ClassWithCommentHeader'
+    assert obj.docstring == " A class with a comment header on the top.\n"
+    method_get_tform = obj.methods['getTransformation']
+    assert method_get_tform.name == 'getTransformation'
+    assert method_get_tform.retv == ['tform']
+    assert method_get_tform.args == ['obj']
+
+
+def test_with_comment_header():
+    mfile = os.path.join(DIRNAME, 'test_data', 'f_with_comment_header.m')
+    obj = mat_types.MatObject.parse_mfile(mfile, 'f_with_comment_header', 'test_data')
+    assert obj.name == 'f_with_comment_header'
+    assert obj.docstring == " A simple function with a comment header on the top.\n"
+
+
+def test_script_with_comment_header():
+    mfile = os.path.join(DIRNAME, 'test_data', 'script_with_comment_header.m')
+    obj = mat_types.MatObject.parse_mfile(mfile, 'script_with_comment_header', 'test_data')
+    assert obj.docstring == ""
 
 
 


### PR DESCRIPTION
I have added a simple function that removes any comment lines at the begin of current read code string.