### PR TITLE
Dependency fix for Sphinx 1.7.

### DIFF
--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -22,7 +22,6 @@ from sphinx.locale import _
 from sphinx.pycode import ModuleAnalyzer as PyModuleAnalyzer, PycodeError
 from sphinx.application import ExtensionError
 from sphinx.util.nodes import nested_parse_with_titles
-from sphinx.util.compat import Directive
 from sphinx.util.inspect import getargspec, isdescriptor, safe_getmembers, \
      safe_getattr, is_builtin_class_method
 try:
@@ -34,7 +33,7 @@ except ImportError:
 from sphinx.util.docstrings import prepare_docstring
 
 from sphinx.ext.autodoc import py_ext_sig_re as mat_ext_sig_re, \
-    DefDict, identity, Options, ALL, INSTANCEATTR, members_option, \
+    identity, Options, ALL, INSTANCEATTR, members_option, \
     members_set_option, SUPPRESS, annotation_option, bool_option, \
     Documenter as PyDocumenter, \
     ModuleDocumenter as PyModuleDocumenter, \

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -15,7 +15,7 @@ from . import mat_documenters as doc
 import re
 
 from docutils import nodes
-from docutils.parsers.rst import directives
+from docutils.parsers.rst import directives, Directive
 
 from sphinx import addnodes
 from sphinx.roles import XRefRole
@@ -23,7 +23,6 @@ from sphinx.locale import l_, _
 from sphinx.domains import Domain, ObjType, Index
 from sphinx.directives import ObjectDescription
 from sphinx.util.nodes import make_refnode
-from sphinx.util.compat import Directive
 from sphinx.util.docfields import Field, GroupedField, TypedField
 
 


### PR DESCRIPTION
Builds are failing for me with Sphinx 1.7.0. These changes resolve the incompatibilities.