### PR TITLE
Feat/member attributes

### DIFF
--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -1297,8 +1297,9 @@ class MatModuleAnalyzer(object):
             if isinstance(v, MatClass):
                 for mk, mv in v.getter('__dict__').items():
                     namespace = '.'.join([mod.package, k])
+                    tagname = '%s.%s' % (k, mk)
                     attr_visitor_collected[namespace, mk] = mv.docstring
-                    attr_visitor_tagorder[mk] = tagnumber
+                    attr_visitor_tagorder[tagname] = tagnumber
                     tagnumber += 1
         self.attr_docs = attr_visitor_collected
         self.tagorder = attr_visitor_tagorder

--- a/tests/test_data/ClassBySource.m
+++ b/tests/test_data/ClassBySource.m
@@ -1,0 +1,22 @@
+classdef ClassBySource
+    % Class which should be printed by source
+
+    methods
+        function testC(obj)
+            % testC function
+            disp('testC');
+        end
+
+        function testB(obj)
+            % testB function
+            disp('testB');
+        end
+
+        function testA(obj)
+            % testA function
+            disp('testA');
+        end
+    end
+    
+end
+

--- a/tests/test_data/ClassWithMethodAttributes.m
+++ b/tests/test_data/ClassWithMethodAttributes.m
@@ -2,37 +2,58 @@ classdef ClassWithMethodAttributes
     % Class with different method attributes
 
     methods
-        function test1(obj)
-            % test1 function
-            disp('test1');
+        function testNormal(obj)
+            % testNormal function
+            disp('testNormal');
+        end
+    end
+
+    methods
+        function testPublic(obj)
+            % testPublic function
+            disp('testPublic');
+        end
+    end
+
+    methods (Access = protected)
+        function testProtected(obj)
+            % testProtected function
+            disp('testProtected');
         end
     end
 
     methods (Access = private)
-        function test2(obj)
-            % test2 function
-            disp('test2');
+        function testPrivate1(obj)
+            % testPrivate1 function
+            disp('testPrivate1');
         end
     end
 
     methods (Access = 'private')
-        function test3(obj)
-            % test3 function
-            disp('test3');
+        function testPrivate2(obj)
+            % testPrivate2 function
+            disp('testPrivate2');
+        end
+    end
+
+    methods (Hidden)
+        function testHidden(obj)
+            % testHidden function
+            disp('testHidden');
         end
     end
 
     methods (Access = ?OtherClass)
-        function test4(obj)
-            % test4 function
-            disp('test4');
+        function testFriend1(obj)
+            % testFriend1 function
+            disp('testFriend1');
         end
     end
 
     methods (Access = {?OtherClass, ?pack.OtherClass2})
-        function test5(obj)
-            % test5 function
-            disp('test5');
+        function testFriend2(obj)
+            % testFriend2 function
+            disp('testFriend2');
         end
     end
     

--- a/tests/test_data/ClassWithMethodAttributes.m
+++ b/tests/test_data/ClassWithMethodAttributes.m
@@ -8,7 +8,7 @@ classdef ClassWithMethodAttributes
         end
     end
 
-    methods
+    methods (Access = public)
         function testPublic(obj)
             % testPublic function
             disp('testPublic');
@@ -40,6 +40,13 @@ classdef ClassWithMethodAttributes
         function testHidden(obj)
             % testHidden function
             disp('testHidden');
+        end
+    end
+
+    methods (Static)
+        function testStatic()
+            % testStatic function
+            disp('testStatic');
         end
     end
 

--- a/tests/test_data/ClassWithPropertyAttributes.m
+++ b/tests/test_data/ClassWithPropertyAttributes.m
@@ -1,0 +1,49 @@
+classdef ClassWithPropertyAttributes
+    % Class with different property attributes
+
+    properties
+        testNormal % Normal public property
+    end
+
+    properties (Access = public)
+        testPublic % Public property
+    end
+
+    properties (Access = protected)
+        testProtected % Protected property
+    end
+
+    properties (Access = private)
+        testPrivate % Private property
+    end
+
+    properties (GetAccess = public, SetAccess = protected)
+        testGetPublic % Get only public property
+    end
+
+    properties (GetAccess = protected, SetAccess = private)
+        testGetProtected % Get only protected property
+    end
+
+    properties (GetAccess = private, SetAccess = private)
+        testGetPrivate % Private property
+    end
+
+    properties (Constant)
+        TEST_CONSTANT % Constant property
+    end
+
+    properties (Access = protected, Constant)
+        TEST_CONSTANT_PROTECTED % Protected constant property
+    end
+
+    properties (Dependent)
+        testDependent % Dependent property
+    end
+
+    properties (Hidden)
+        testHidden % Hidden property
+    end
+    
+end
+

--- a/tests/test_docs/index.rst
+++ b/tests/test_docs/index.rst
@@ -78,7 +78,7 @@ A method in ClassExample
 .. automethod:: ClassExample.mymethod
 
 A class using bysource ordering
-+++++++++++++++++++++++++++++
++++++++++++++++++++++++++++++++
 
 Using `bysource` ordering instead of default `alphabetic`
 

--- a/tests/test_docs/index.rst
+++ b/tests/test_docs/index.rst
@@ -100,12 +100,107 @@ A Matlab class with property validation
 
 ClassWithMethodAttributes
 +++++++++++++++++++++++++
+
 A Matlab class with different method attributes
+
+.. literalinclude:: ../test_data/ClassWithMethodAttributes.m
+   :language: matlab
+
+Public methods
+~~~~~~~~~~~~~~
+
+By default only the public methods will be included
 
 .. autoclass:: ClassWithMethodAttributes
     :members:
     :show-inheritance:
 
+Protected methods
+~~~~~~~~~~~~~~~~~
+
+Including the protected members as well
+
+.. autoclass:: ClassWithMethodAttributes
+    :members:
+    :show-inheritance:
+    :protected-members:
+
+Private methods
+~~~~~~~~~~~~~~~
+
+Including the private members as well
+
+.. autoclass:: ClassWithMethodAttributes
+    :members:
+    :show-inheritance:
+    :private-members:
+
+Hidden methods
+~~~~~~~~~~~~~~
+
+Including the hidden members as well
+
+.. autoclass:: ClassWithMethodAttributes
+    :members:
+    :show-inheritance:
+    :hidden-members:
+
+Friend methods
+~~~~~~~~~~~~~~
+
+Including the friend members as well
+
+.. autoclass:: ClassWithMethodAttributes
+    :members:
+    :show-inheritance:
+    :friend-members:
+
+ClassWithPropertyAttributes
++++++++++++++++++++++++++++
+
+A Matlab class with different property attributes
+
+.. literalinclude:: ../test_data/ClassWithPropertyAttributes.m
+   :language: matlab
+
+Public properties
+~~~~~~~~~~~~~~~~~
+
+By default only the public properties will be included
+
+.. autoclass:: ClassWithPropertyAttributes
+    :members:
+    :show-inheritance:
+
+Protected properties
+~~~~~~~~~~~~~~~~~~~~
+
+Including the protected members as well
+
+.. autoclass:: ClassWithPropertyAttributes
+    :members:
+    :show-inheritance:
+    :protected-members:
+
+Private properties
+~~~~~~~~~~~~~~~~~~
+
+Including the private members as well
+
+.. autoclass:: ClassWithPropertyAttributes
+    :members:
+    :show-inheritance:
+    :private-members:
+
+Hidden properties
+~~~~~~~~~~~~~~~~~
+
+Including the hidden members as well
+
+.. autoclass:: ClassWithPropertyAttributes
+    :members:
+    :show-inheritance:
+    :hidden-members:
 
 ClassWithAttributes
 +++++++++++++++++++

--- a/tests/test_docs/index.rst
+++ b/tests/test_docs/index.rst
@@ -37,8 +37,8 @@ Should show inheritance and members.
 
 .. _ClassAbstract:
 
-A Abstract Class
-++++++++++++++++
+An Abstract Class
++++++++++++++++++
 Should show inheritance and members.
 
 .. autoclass:: ClassAbstract
@@ -76,6 +76,16 @@ my method
 A method in ClassExample
 
 .. automethod:: ClassExample.mymethod
+
+A class using bysource ordering
++++++++++++++++++++++++++++++
+
+Using `bysource` ordering instead of default `alphabetic`
+
+.. autoclass:: ClassBySource
+    :show-inheritance:
+    :members:
+    :member-order: bysource
 
 A class with ellipsis properties
 ++++++++++++++++++++++++++++++++

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -51,7 +51,7 @@ def test_module(mod):
     assert not mod.getter('__module__')
     assert not mod.getter('__doc__')
     all_items = set(mod.getter('__all__'))
-    expected_items = {'+package', '@ClassFolder', 'ClassAbstract', 'ClassExample',
+    expected_items = {'+package', '@ClassFolder', 'ClassAbstract', 'ClassExample', 'ClassBySource',
                       'ClassInheritHandle', 'ClassWithEllipsisProperties',
                       'ClassWithEndOfLineComment', 'f_example', 'f_with_nested_function',
                       'submodule', 'script', 'Bool', 'ClassWithEvent',
@@ -59,7 +59,7 @@ def test_module(mod):
                       'f_with_comment_header', 'script_with_comment_header',
                       'script_with_comment_header_2', 'script_with_comment_header_3',
                       'script_with_comment_header_4',
-                      'PropTypeOld', 'ValidateProps', 'ClassWithMethodAttributes',
+                      'PropTypeOld', 'ValidateProps', 'ClassWithMethodAttributes', 'ClassWithPropertyAttributes',
                       'ClassWithoutIndent', 'f_with_utf8', 'f_with_name_mismatch',
                       'ClassWithBuiltinOverload', 'ClassWithFunctionVariable',
                       'ClassWithErrors', 'f_inputargs_error',

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -270,11 +270,33 @@ def test_ClassWithMethodAttributes():
     obj = mat_types.MatObject.parse_mfile(mfile, 'ClassWithMethodAttributes', 'test_data')
     assert obj.name == 'ClassWithMethodAttributes'
     assert obj.docstring == " Class with different method attributes\n"
-    assert obj.methods['test1'].attrs == {}
-    assert obj.methods['test2'].attrs == {'Access': 'private'}
-    assert obj.methods['test3'].attrs == {'Access': 'private'}
-    assert obj.methods['test4'].attrs == {'Access': '?OtherClass'}
-    assert obj.methods['test5'].attrs == {'Access': ['?OtherClass', '?pack.OtherClass2']}
+    assert obj.methods['testNormal'].attrs == {}
+    assert obj.methods['testPublic'].attrs == {'Access': 'public'}
+    assert obj.methods['testProtected'].attrs == {'Access': 'protected'}
+    assert obj.methods['testPrivate1'].attrs == {'Access': 'private'}
+    assert obj.methods['testPrivate2'].attrs == {'Access': 'private'}
+    assert obj.methods['testHidden'].attrs == {'Hidden': True}
+    assert obj.methods['testStatic'].attrs == {'Static': True}
+    assert obj.methods['testFriend1'].attrs == {'Access': '?OtherClass'}
+    assert obj.methods['testFriend2'].attrs == {'Access': ['?OtherClass', '?pack.OtherClass2']}
+
+
+def test_ClassWithPropertyAttributes():
+    mfile = os.path.join(DIRNAME, 'test_data', 'ClassWithPropertyAttributes.m')
+    obj = mat_types.MatObject.parse_mfile(mfile, 'ClassWithPropertyAttributes', 'test_data')
+    assert obj.name == 'ClassWithPropertyAttributes'
+    assert obj.docstring == " Class with different property attributes\n"
+    assert obj.properties['testNormal']['attrs'] == {}
+    assert obj.properties['testPublic']['attrs'] == {'Access': 'public'}
+    assert obj.properties['testProtected']['attrs'] == {'Access': 'protected'}
+    assert obj.properties['testPrivate']['attrs'] == {'Access': 'private'}
+    assert obj.properties['testGetPublic']['attrs'] == {'GetAccess': 'public', 'SetAccess': 'protected'}
+    assert obj.properties['testGetProtected']['attrs'] == {'GetAccess': 'protected', 'SetAccess': 'private'}
+    assert obj.properties['testGetPrivate']['attrs'] == {'GetAccess': 'private', 'SetAccess': 'private'}
+    assert obj.properties['TEST_CONSTANT']['attrs'] == {'Constant': True}
+    assert obj.properties['TEST_CONSTANT_PROTECTED']['attrs'] == {'Access': 'protected', 'Constant': True}
+    assert obj.properties['testDependent']['attrs'] == {'Dependent': True}
+    assert obj.properties['testHidden']['attrs'] == {'Hidden': True}
 
 
 def test_ClassWithoutIndent():


### PR DESCRIPTION
Created correct filter for private, protected, hidden and friend members #24 .
Added option for enabling these:

-  private-members: Show all or the selected few
-  protected-members: Show all or the selected few
-  hidden-members: Show all or the selected few

- friend-members: Show all or only those methods which are friend of selected meta classes

Fix bysource ordering #75 .