### PR TITLE
Fix autodoc parsing error when source matlab file is not encoded as UTF-8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,9 @@ In order for the Sphinx MATLAB domain to auto-document MATLAB source code, set
 the config value of ``matlab_src_dir`` to the absolute path instead of adding
 them to ``sys.path``. Currently only one MATLAB path can be specified, but all
 subfolders in that tree will be searched.
+The encoding of the matlab files can be specified using the config value of
+``matlab_src_encoding``. By default, the files will be read as utf-8 and parsing
+errors will be replaced using ? chars.
 
 For convenience the `primary domain <http://sphinx-doc.org/config.html#confval-primary_domain>`_
 can be set to ``mat``.

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -116,6 +116,9 @@ class MatlabDocumenter(PyDocumenter):
         MatObject.basedir = basedir  # set MatObject base directory
         MatObject.sphinx_env = self.env  # pass env to MatObject cls
         MatObject.sphinx_app = self.env.app  # pass app to MatObject cls
+
+        # sets Matlab src file encoding for parsing
+        MatObject.encoding = self.env.config.matlab_src_encoding
         if self.objpath:
             logger.debug('[autodoc] from %s import %s',
                 self.modname, '.'.join(self.objpath))

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -50,6 +50,7 @@ class MatObject(object):
     ``function`` or ``classdef`` keywords.
     """
     basedir = None
+    encoding = None
     sphinx_env = None
     sphinx_app = None
 
@@ -122,11 +123,11 @@ class MatObject(object):
             mfile = fullpath + '.m'
             msg = '[%s] matlabify %s from\n\t%s.'
             logger.debug(msg, MAT_DOM, package, mfile)
-            return MatObject.parse_mfile(mfile, name, path)  # parse mfile
+            return MatObject.parse_mfile(mfile, name, path, MatObject.encoding)  # parse mfile
         return None
 
     @staticmethod
-    def parse_mfile(mfile, name, path):
+    def parse_mfile(mfile, name, path, encoding=None):
         """
         Use Pygments to parse mfile to determine type: function or class.
 
@@ -136,14 +137,21 @@ class MatObject(object):
         :type name: str
         :param path: Path of module containing :class:`MatObject`.
         :type path: str
+        :param encoding: Encoding of the Matlab file to load (default = utf-8)
+        :type encoding: str
         :returns: :class:`MatObject` that represents the type of mfile.
 
         Assumes that the first token in the file is either one of the keywords:
         "classdef" or "function" otherwise it is assumed to be a script.
+
+        File encoding can be set using sphinx config ``matlab_src_encoding``
+        Default behaviour : replaces parsing errors with ? chars
         """
         # use Pygments to parse mfile to determine type: function/classdef
         # read mfile code
-        with open(mfile, 'r', encoding='utf-8') as code_f:
+        if encoding is None:
+            encoding = 'utf-8'
+        with open(mfile, 'r', encoding=encoding, errors='replace') as code_f:
             code = code_f.read().replace('\r\n', '\n')
 
         full_code = code

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -716,6 +716,7 @@ def setup(app):
     app.add_domain(MATLABDomain)
     # autodoc
     app.add_config_value('matlab_src_dir', None, 'env')
+    app.add_config_value('matlab_src_encoding', None, 'env')
     app.add_autodocumenter(doc.MatModuleDocumenter)
     app.add_autodoc_attrgetter(doc.MatModule, doc.MatModule.getter)
     app.add_autodocumenter(doc.MatClassDocumenter)

--- a/tests/test_data/f_with_latin_1.m
+++ b/tests/test_data/f_with_latin_1.m
@@ -1,0 +1,4 @@
+function step_analysis = f_with_latin_1(X,Y,i_start,i_end,setpoints)
+% Analyse de la réponse à un créneau
+step_analysis = 42;
+end

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -60,7 +60,7 @@ def test_module(mod):
                       'script_with_comment_header_2', 'script_with_comment_header_3',
                       'script_with_comment_header_4',
                       'PropTypeOld', 'ValidateProps', 'ClassWithMethodAttributes', 'ClassWithPropertyAttributes',
-                      'ClassWithoutIndent', 'f_with_utf8', 'f_with_name_mismatch',
+                      'ClassWithoutIndent', 'f_with_utf8', 'f_with_latin_1', 'f_with_name_mismatch',
                       'ClassWithBuiltinOverload', 'ClassWithFunctionVariable',
                       'ClassWithErrors', 'f_inputargs_error',
                       'ClassWithAttributes', 'ClassWithLineContinuation',

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -313,6 +313,13 @@ def test_f_with_utf8():
     assert obj.docstring == " Cambia ubicación de partículas.\n"
 
 
+def test_file_parsing_encoding_can_be_specified():
+    mfile = os.path.join(DIRNAME, 'test_data', 'f_with_latin_1.m')
+    obj = mat_types.MatObject.parse_mfile(mfile, 'f_with_latin_1', 'test_data', encoding='latin-1')
+    assert obj.name == 'f_with_latin_1'
+    assert obj.docstring == " Analyse de la réponse à un créneau\n"
+
+
 def test_ClassWithBuiltinOverload():
     mfile = os.path.join(DIRNAME, 'test_data', 'ClassWithBuiltinOverload.m')
     obj = mat_types.MatObject.parse_mfile(mfile, 'ClassWithBuiltinOverload', 'test_data')


### PR DESCRIPTION
Hi !

I tried using your tool for our projects and I had some problems for non UTF-8 files (parser would crash on autodoc parsing).
I made the following changes to handle it :

- Added default behavior to replace errors with ? chars
- Added sphinx configuration to choose parsing encoding (default = UTF-8)

I added the corresponding unit test and documentation.
Please tell me if you have any remarks regarding this pull request.