### PR TITLE
Added an option to strip the MATLAB package '+' prefix in output.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,12 @@ Additional Configuration
    The encoding of the MATLAB files. By default, the files will be read as utf-8
    and parsing errors will be replaced using ? chars.
 
+``matlab_keep_package_prefix``
+   Determines if the MATLAB package prefix ``+`` is displayed in the
+   generated documentation.  Default is true.  When false, packages are
+   still referred to in ReST using ``+pakage.+subpkg.func`` but the output
+   will be ``pakage.other.func()``.
+
 For convenience the `primary domain <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-primary_domain>`_
 can be set to ``mat``.
 

--- a/tests/roots/test_package_prefix/+package/+subpkg/func.m
+++ b/tests/roots/test_package_prefix/+package/+subpkg/func.m
@@ -1,0 +1,5 @@
+function m = func(x)
+  % Returns x
+
+  m = x;
+end

--- a/tests/roots/test_package_prefix/+package/func.m
+++ b/tests/roots/test_package_prefix/+package/func.m
@@ -1,0 +1,4 @@
+function y = func(x)
+% Returns x
+
+y = x;

--- a/tests/roots/test_package_prefix/Makefile
+++ b/tests/roots/test_package_prefix/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SPHINXPROJ    = test_autodoc
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/tests/roots/test_package_prefix/conf.py
+++ b/tests/roots/test_package_prefix/conf.py
@@ -1,0 +1,15 @@
+import os
+import sys
+matlab_src_dir = os.path.abspath('.')
+
+primary_domain = "mat"
+
+# This option is set in the test script: test_package_prefix.py
+#matlab_keep_package_prefix = False
+
+extensions = ['sphinx.ext.autodoc', 'sphinxcontrib.matlab']
+
+# The master toctree document.
+master_doc = 'index'
+source_suffix = '.rst'
+nitpicky = True

--- a/tests/roots/test_package_prefix/index.rst
+++ b/tests/roots/test_package_prefix/index.rst
@@ -1,0 +1,17 @@
+
+This is a :func:`+package.func`.
+
+.. automodule:: +package
+.. autofunction:: func
+
+.. automodule:: +package.+subpkg
+.. autofunction:: func
+
+This is a :func:`func`.
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* `MATLAB Module Index <mat-modindex.html>`_
+* :ref:`search`

--- a/tests/roots/test_package_prefix/make.bat
+++ b/tests/roots/test_package_prefix/make.bat
@@ -1,0 +1,36 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+set SPHINXPROJ=test_autodoc
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+
+:end
+popd

--- a/tests/test_package_prefix.py
+++ b/tests/test_package_prefix.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""
+    test_package_function
+    ~~~~~~~~~~~~~~~~~~~~~
+
+    Test the autodoc extension with the matlab_keep_package_prefix option.
+
+    :copyright: Copyright 2019 by the Isaac Lenton.
+    :license: BSD, see LICENSE for details.
+"""
+from __future__ import unicode_literals
+import pickle
+import os
+
+import pytest
+
+from sphinx import addnodes
+from sphinx.testing.fixtures import make_app, test_params   # noqa: F811;
+from sphinx.testing.path import path
+
+
+@pytest.fixture(scope='module')
+def rootdir():
+    return path(os.path.dirname(__file__)).abspath()
+
+
+def test_with_prefix(make_app, rootdir):
+    srcdir = rootdir / 'roots' / 'test_package_prefix'
+    app = make_app(srcdir=srcdir)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / 'index.doctree').bytes())
+
+    assert isinstance(content[4], addnodes.desc)
+    assert content[4].astext() == '+package.funcx\n\nReturns x'
+
+
+def test_without_prefix(make_app, rootdir):
+    srcdir = rootdir / 'roots' / 'test_package_prefix'
+    confdict = { 'matlab_keep_package_prefix' : False }
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / 'index.doctree').bytes())
+
+    assert isinstance(content[4], addnodes.desc)
+    assert content[4].astext() == 'package.funcx\n\nReturns x'
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
When false, packages are still referred to in ReST using
``+pakage.+subpkg.func`` but the output will be ``pakage.other.func()``.

This is useful for making the output seem more like what the user would encounter
when using the MATLAB package.

Perhaps it would be good to consider making this option default to False?