### PR TITLE
Bug 103 fixed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+sphinxcontrib-matlabdomain-0.11.2 (2020-05-18)
+==============================================
+
+* Fixed `Issue 103 <https://github.com/sphinx-contrib/matlabdomain/issues/103>`_.
+  If a double quoted string was followed by a single qouted string, the lexer
+  would produce incorrect token, causing the a parser warning. Fixed by merging
+  parts from pygments.
+
+
 sphinxcontrib-matlabdomain-0.11.1 (2020-01-07)
 ==============================================
 

--- a/sphinxcontrib/mat_lexer.py
+++ b/sphinxcontrib/mat_lexer.py
@@ -124,14 +124,15 @@ class MatlabLexer(RegexLexer):
             (r'\d+[eEf][+-]?[0-9]+', Number.Float),
             (r'\d+', Number.Integer),
 
+            (r'"(""|[^"])*"', String),
+
             (r'(?<![\w)\].])\'', String, 'string'),
-            (r'(?<![\w)\].])\"', String, 'string'),
+			
             (r'[a-zA-Z_]\w*', Name),
             (r'.', Text),
         ],
-        'string': [
-            (r'[^\']*\'', String, '#pop'),
-            (r'[^\"]*\"', String, '#pop')
+       'string': [
+            (r"[^']*'", String, '#pop'),
         ],
         'blockcomment': [
             (r'^\s*%\}', Comment.Multiline, '#pop'),

--- a/tests/test_data/ClassWithStrings.m
+++ b/tests/test_data/ClassWithStrings.m
@@ -1,0 +1,9 @@
+classdef ClassWithStrings
+    methods
+        function obj = raiseError(obj)
+            % Raises error with string
+            errStr = "Hello World";
+            error('ErrorID', errStr)
+        end
+    end
+end

--- a/tests/test_docs/index.rst
+++ b/tests/test_docs/index.rst
@@ -265,6 +265,14 @@ A MATLAB class with strings using double quotes.
 .. autoclass:: ClassWithDoubleQuotedString
     :members:
 
+ClassWithStrings
+++++++++++++++++
+
+A MATLAB class with strings using single and double quotes.
+
+.. autoclass:: ClassWithStrings
+    :members:
+
 ClassWithDummyArguments
 +++++++++++++++++++++++
 

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -5,7 +5,11 @@ from sphinxcontrib.mat_lexer import MatlabLexer, Token
 def test_strings():
     tokens = list(MatlabLexer().get_tokens("'happy'\"happy\""))
     assert tokens[0:2] == [(Token.Literal.String, "'"), (Token.Literal.String, "happy'")]
-    assert tokens[2:4] == [(Token.Literal.String, '"'), (Token.Literal.String, 'happy"')]
+    assert tokens[2:4] == [(Token.Literal.String, '"happy"'), (Token.Text, '\n')]
+
+    tokens = list(MatlabLexer().get_tokens('"happy"\'happy\''))
+    assert tokens[0:2] == [(Token.Literal.String, '"happy"'), (Token.Literal.String, "'")]
+    assert tokens[2:4] == [(Token.Literal.String, "happy'"), (Token.Text, '\n')]
 
 
 def test_function_names():

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -68,7 +68,8 @@ def test_module(mod):
                       'ClassWithUnknownAttributes', 'ClassWithNameMismatch',
                       'ClassWithEnumMethod', 'ClassWithEventMethod', 'f_with_function_variable',
                       'ClassWithUndocumentedMembers', 'ClassWithGetterSetter',
-                      'ClassWithDoubleQuotedString', 'ClassWithDummyArguments'}
+                      'ClassWithDoubleQuotedString', 'ClassWithDummyArguments',
+                      'ClassWithStrings'}
     assert all_items == expected_items
     assert mod.getter('__name__') in modules
 

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -479,6 +479,13 @@ def test_ClassWithDoubleQuotedString():
                                             'attrs': {},
                                             'default': None}}
 
+def test_ClassWithStrings():
+    mfile = os.path.join(DIRNAME, 'test_data', 'ClassWithStrings.m')
+    obj = mat_types.MatObject.parse_mfile(mfile, 'ClassWithStrings', 'test_data')
+    assert isinstance(obj, mat_types.MatClass)
+    assert obj.name == 'ClassWithStrings'
+    assert set(obj.methods.keys()) == set(['raiseError'])
+
 
 def test_ClassWithDummyArguments():
     mfile = os.path.join(DIRNAME, 'test_data', 'ClassWithDummyArguments.m')


### PR DESCRIPTION
Fixed #103 
If a double quoted string was followed by a single quoted string, the lexer
would produce incorrect token, causing the a parser warning. Fixed by merging
parts from pygments.