### PR TITLE
Fix tests due to Sphinx 3.1.1 changes

### DIFF
--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -32,7 +32,7 @@ def test_setup(make_app, rootdir):
     content = pickle.loads((app.doctreedir / 'index.doctree').bytes())
 
     assert isinstance(content[3], addnodes.desc)
-    assert content[3][0].astext() == 'class target.ClassExamplea'
+    assert content[3][0].astext() == 'class target.ClassExample(a)'
     assert content[3][1].astext() == """Bases: handle
 
 Example class
@@ -49,7 +49,7 @@ a property
 
 
 
-mymethodb
+mymethod(b)
 
 A method in ClassExample
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -11,6 +11,7 @@
 from __future__ import unicode_literals
 import pickle
 import os
+import sys
 
 import pytest
 
@@ -24,6 +25,7 @@ def rootdir():
     return path(os.path.dirname(__file__)).abspath()
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_setup(make_app, rootdir):
     srcdir = rootdir / 'roots' / 'test_autodoc'
     app = make_app(srcdir=srcdir)

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -31,7 +31,7 @@ def test_setup(make_app, rootdir):
     app = make_app(srcdir=srcdir)
     app.builder.build_all()
 
-    content = pickle.loads((app.doctreedir / 'index.doctree').bytes())
+    content = pickle.loads((app.doctreedir / 'index.doctree').read_bytes())
 
     assert isinstance(content[3], addnodes.desc)
     assert content[3][0].astext() == 'class target.ClassExample(a)'

--- a/tests/test_package_links.py
+++ b/tests/test_package_links.py
@@ -32,7 +32,7 @@ def test_with_prefix(make_app, rootdir):
     app = make_app(srcdir=srcdir)
     app.builder.build_all()
 
-    content = pickle.loads((app.doctreedir / 'contents.doctree').bytes())
+    content = pickle.loads((app.doctreedir / 'contents.doctree').read_bytes())
 
     assert isinstance(content[3], addnodes.desc)
     assert content[3].astext() == 'class +replab.Str\n\nBases: handle\n\nDefines a ‘str’ default method and overloads ‘disp’'
@@ -47,7 +47,7 @@ def test_without_prefix(make_app, rootdir):
     app = make_app(srcdir=srcdir, confoverrides=confdict)
     app.builder.build_all()
 
-    content = pickle.loads((app.doctreedir / 'contents.doctree').bytes())
+    content = pickle.loads((app.doctreedir / 'contents.doctree').read_bytes())
 
     assert isinstance(content[3], addnodes.desc)
     assert content[3].astext() == 'class replab.Str\n\nBases: handle\n\nDefines a ‘str’ default method and overloads ‘disp’'

--- a/tests/test_package_links.py
+++ b/tests/test_package_links.py
@@ -11,6 +11,7 @@
 from __future__ import unicode_literals
 import pickle
 import os
+import sys
 
 import pytest
 
@@ -25,6 +26,7 @@ def rootdir():
     return path(os.path.dirname(__file__)).abspath()
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_with_prefix(make_app, rootdir):
     srcdir = rootdir / 'roots' / 'test_package_links'
     app = make_app(srcdir=srcdir)
@@ -38,6 +40,7 @@ def test_with_prefix(make_app, rootdir):
     assert content[5].astext() == 'class +replab.Action\n\nBases: +replab.Str\n\nAn action group …\n\n\n\nleftAction(self, g, p)\n\nReturns the left action'
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_without_prefix(make_app, rootdir):
     srcdir = rootdir / 'roots' / 'test_package_links'
     confdict = { 'matlab_keep_package_prefix' : False }

--- a/tests/test_package_links.py
+++ b/tests/test_package_links.py
@@ -35,7 +35,7 @@ def test_with_prefix(make_app, rootdir):
     assert isinstance(content[3], addnodes.desc)
     assert content[3].astext() == 'class +replab.Str\n\nBases: handle\n\nDefines a ‘str’ default method and overloads ‘disp’'
     assert isinstance(content[5], addnodes.desc)
-    assert content[5].astext() == 'class +replab.Action\n\nBases: +replab.Str\n\nAn action group …\n\n\n\nleftActionself, g, p\n\nReturns the left action'
+    assert content[5].astext() == 'class +replab.Action\n\nBases: +replab.Str\n\nAn action group …\n\n\n\nleftAction(self, g, p)\n\nReturns the left action'
 
 
 def test_without_prefix(make_app, rootdir):
@@ -49,7 +49,7 @@ def test_without_prefix(make_app, rootdir):
     assert isinstance(content[3], addnodes.desc)
     assert content[3].astext() == 'class replab.Str\n\nBases: handle\n\nDefines a ‘str’ default method and overloads ‘disp’'
     assert isinstance(content[5], addnodes.desc)
-    assert content[5].astext() == 'class replab.Action\n\nBases: replab.Str\n\nAn action group …\n\n\n\nleftActionself, g, p\n\nReturns the left action'
+    assert content[5].astext() == 'class replab.Action\n\nBases: replab.Str\n\nAn action group …\n\n\n\nleftAction(self, g, p)\n\nReturns the left action'
 
 
 

--- a/tests/test_package_prefix.py
+++ b/tests/test_package_prefix.py
@@ -31,7 +31,7 @@ def test_with_prefix(make_app, rootdir):
     app = make_app(srcdir=srcdir)
     app.builder.build_all()
 
-    content = pickle.loads((app.doctreedir / 'index.doctree').bytes())
+    content = pickle.loads((app.doctreedir / 'index.doctree').read_bytes())
 
     assert isinstance(content[4], addnodes.desc)
     assert content[4].astext() == '+package.func(x)\n\nReturns x'
@@ -44,7 +44,7 @@ def test_without_prefix(make_app, rootdir):
     app = make_app(srcdir=srcdir, confoverrides=confdict)
     app.builder.build_all()
 
-    content = pickle.loads((app.doctreedir / 'index.doctree').bytes())
+    content = pickle.loads((app.doctreedir / 'index.doctree').read_bytes())
 
     assert isinstance(content[4], addnodes.desc)
     assert content[4].astext() == 'package.func(x)\n\nReturns x'

--- a/tests/test_package_prefix.py
+++ b/tests/test_package_prefix.py
@@ -32,7 +32,7 @@ def test_with_prefix(make_app, rootdir):
     content = pickle.loads((app.doctreedir / 'index.doctree').bytes())
 
     assert isinstance(content[4], addnodes.desc)
-    assert content[4].astext() == '+package.funcx\n\nReturns x'
+    assert content[4].astext() == '+package.func(x)\n\nReturns x'
 
 
 def test_without_prefix(make_app, rootdir):
@@ -44,7 +44,7 @@ def test_without_prefix(make_app, rootdir):
     content = pickle.loads((app.doctreedir / 'index.doctree').bytes())
 
     assert isinstance(content[4], addnodes.desc)
-    assert content[4].astext() == 'package.funcx\n\nReturns x'
+    assert content[4].astext() == 'package.func(x)\n\nReturns x'
 
 
 if __name__ == '__main__':

--- a/tests/test_package_prefix.py
+++ b/tests/test_package_prefix.py
@@ -11,6 +11,7 @@
 from __future__ import unicode_literals
 import pickle
 import os
+import sys
 
 import pytest
 
@@ -24,6 +25,7 @@ def rootdir():
     return path(os.path.dirname(__file__)).abspath()
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_with_prefix(make_app, rootdir):
     srcdir = rootdir / 'roots' / 'test_package_prefix'
     app = make_app(srcdir=srcdir)
@@ -35,6 +37,7 @@ def test_with_prefix(make_app, rootdir):
     assert content[4].astext() == '+package.func(x)\n\nReturns x'
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_without_prefix(make_app, rootdir):
     srcdir = rootdir / 'roots' / 'test_package_prefix'
     confdict = { 'matlab_keep_package_prefix' : False }

--- a/tests/test_pymat.py
+++ b/tests/test_pymat.py
@@ -31,7 +31,7 @@ def test_setup(make_app, rootdir):
     app = make_app(srcdir=srcdir)
     app.builder.build_all()
 
-    content = pickle.loads((app.doctreedir / 'index.doctree').bytes())
+    content = pickle.loads((app.doctreedir / 'index.doctree').read_bytes())
 
     assert isinstance(content[3], addnodes.desc)
     assert content[3].astext() == 'func.main()\n\nReturns the answer.'

--- a/tests/test_pymat.py
+++ b/tests/test_pymat.py
@@ -32,10 +32,10 @@ def test_setup(make_app, rootdir):
     content = pickle.loads((app.doctreedir / 'index.doctree').bytes())
 
     assert isinstance(content[3], addnodes.desc)
-    assert content[3].astext() == 'func.main\n\nReturns the answer.'
+    assert content[3].astext() == 'func.main()\n\nReturns the answer.'
 
     assert isinstance(content[7], addnodes.desc)
-    assert content[7].astext() == 'matsrc.funcx\n\nReturns x'
+    assert content[7].astext() == 'matsrc.func(x)\n\nReturns x'
 
 
 if __name__ == '__main__':

--- a/tests/test_pymat.py
+++ b/tests/test_pymat.py
@@ -11,6 +11,7 @@
 from __future__ import unicode_literals
 import pickle
 import os
+import sys
 
 import pytest
 
@@ -24,6 +25,7 @@ def rootdir():
     return path(os.path.dirname(__file__)).abspath()
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_setup(make_app, rootdir):
     srcdir = rootdir / 'roots' / 'test_pymat'
     app = make_app(srcdir=srcdir)

--- a/tests/test_pymat_common_root.py
+++ b/tests/test_pymat_common_root.py
@@ -11,6 +11,7 @@
 from __future__ import unicode_literals
 import pickle
 import os
+import sys
 
 import pytest
 

--- a/tests/test_pymat_common_root.py
+++ b/tests/test_pymat_common_root.py
@@ -24,6 +24,7 @@ def rootdir():
     return path(os.path.dirname(__file__)).abspath()
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_setup(make_app, rootdir):
     srcdir = rootdir / 'roots' / 'test_pymat_common_root'
     app = make_app(srcdir=srcdir)

--- a/tests/test_pymat_common_root.py
+++ b/tests/test_pymat_common_root.py
@@ -29,7 +29,7 @@ def test_setup(make_app, rootdir):
     app = make_app(srcdir=srcdir)
     app.builder.build_all()
 
-    content = pickle.loads((app.doctreedir / 'index.doctree').bytes())
+    content = pickle.loads((app.doctreedir / 'index.doctree').read_bytes())
 
     assert isinstance(content[4], addnodes.desc)
     assert content[4].astext().startswith('class base.PythonClass.PythonClass')


### PR DESCRIPTION
* Sphinx 3.1.1 changed API. (``as_text()`` output and using ``read_bytes`` instead of ``bytes``.
* Some tests are now skipped for Python 2.7