### PR TITLE
Enable Function Arguments Support

### DIFF
--- a/sphinxcontrib/mat_lexer.py
+++ b/sphinxcontrib/mat_lexer.py
@@ -96,10 +96,11 @@ class MatlabLexer(RegexLexer):
 
             # from 'iskeyword' on version 7.11 (R2010):
             (words((
-                'break', 'case', 'catch', 'classdef', 'continue', 'else', 'elseif',
-                'end', 'enumerated', 'events', 'for', 'global', 'if',
-                'methods', 'otherwise', 'parfor', 'persistent', 'properties',
-                'return', 'spmd', 'switch', 'try', 'while'), suffix=r'\b'),
+                'arguments', 'break', 'case', 'catch', 'classdef', 'continue', 
+                'else', 'elseif', 'end', 'enumerated', 'events', 'for', 
+                'global', 'if', 'methods', 'otherwise', 'parfor',
+                'persistent', 'properties', 'return', 'spmd', 'switch', 'try', 
+                'while'), suffix=r'\b'),
              Keyword),
 
             ("(" + "|".join(elfun + specfun + elmat) + r')\b',  Name.Builtin),

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -515,8 +515,8 @@ class MatFunction(MatObject):
     :type tokens: list
     """
     # MATLAB keywords that increment keyword-end pair count
-    mat_kws = list(zip((Token.Keyword,) * 5,
-                  ('if', 'while', 'for', 'switch', 'try')))
+    mat_kws = list(zip((Token.Keyword,) * 6,
+                  ('arguments', 'for', 'if', 'switch', 'try', 'while')))
 
     def __init__(self, name, modname, tokens):
         super(MatFunction, self).__init__(name)

--- a/tests/test_data/ClassWithFunctionArguments.m
+++ b/tests/test_data/ClassWithFunctionArguments.m
@@ -9,7 +9,7 @@ classdef ClassWithFunctionArguments < handle
     methods
         function mc = ClassExample(a)
             arguments
-                a;
+                a
             end
             mc.a = a
         end
@@ -18,8 +18,8 @@ classdef ClassWithFunctionArguments < handle
         %
         % :param b: an input to :meth:`mymethod`
             arguments
-                obj;
-                b = 1;
+                obj
+                b = 1
             end
             for n = 1:10
                 if n > 5
@@ -31,8 +31,8 @@ classdef ClassWithFunctionArguments < handle
         end
         function c = nondocumentedmethod(obj, b)
             arguments
-                obj;
-                b = 1;
+                obj
+                b = 1
             end
             for n = 1:10
                 if n > 5

--- a/tests/test_data/ClassWithFunctionArguments.m
+++ b/tests/test_data/ClassWithFunctionArguments.m
@@ -1,0 +1,46 @@
+classdef ClassWithFunctionArguments < handle
+    % test class methods with function arguments
+    %
+    % :param a: the input to :class:`ClassWithFunctionArguments`
+    
+    properties
+        a % a property
+    end
+    methods
+        function mc = ClassExample(a)
+            arguments
+                a;
+            end
+            mc.a = a
+        end
+        function c = mymethod(obj, b)
+        % a method in :class:`ClassWithFunctionArguments`
+        %
+        % :param b: an input to :meth:`mymethod`
+            arguments
+                obj;
+                b = 1;
+            end
+            for n = 1:10
+                if n > 5
+                    c = obj.a + b
+                else
+                    c = obj.a + b^2
+                end
+            end
+        end
+        function c = nondocumentedmethod(obj, b)
+            arguments
+                obj;
+                b = 1;
+            end
+            for n = 1:10
+                if n > 5
+                    c = obj.a + b
+                else
+                    c = obj.a + b^2
+                end
+            end
+        end
+    end
+end

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -69,7 +69,7 @@ def test_module(mod):
                       'ClassWithEnumMethod', 'ClassWithEventMethod', 'f_with_function_variable',
                       'ClassWithUndocumentedMembers', 'ClassWithGetterSetter',
                       'ClassWithDoubleQuotedString', 'ClassWithDummyArguments',
-                      'ClassWithStrings'}
+                      'ClassWithStrings', 'ClassWithFunctionArguments'}
     assert all_items == expected_items
     assert mod.getter('__name__') in modules
 

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -162,6 +162,19 @@ def test_ClassWithEvent():
     assert obj.docstring == ""
 
 
+def test_ClassWithFunctionArguments():
+    # TODO: handle 'events' block
+    mfile = os.path.join(DIRNAME, 'test_data', 'ClassWithFunctionArguments.m')
+    obj = mat_types.MatObject.parse_mfile(mfile, 'ClassWithFunctionArguments', 'test_data')
+    assert obj.name == 'ClassWithFunctionArguments'
+    assert obj.docstring == " test class methods with function arguments\n\n :param a: the input to :class:`ClassWithFunctionArguments`\n"
+    mymethod = obj.methods['mymethod']
+    assert mymethod.name == 'mymethod'
+    assert mymethod.retv == ['c']
+    assert mymethod.args == ['obj', 'b']
+    assert mymethod.docstring == " a method in :class:`ClassWithFunctionArguments`\n\n :param b: an input to :meth:`mymethod`\n"
+
+
 def test_EnumerationBool():
     # TODO: handle 'enumeration' block
     mfile = os.path.join(DIRNAME, 'test_data', 'Bool.m')


### PR DESCRIPTION
This commit adds support for function argument validation, as added in MATLAB 2019b and detailed [here](https://uk.mathworks.com/help/matlab/matlab_prog/function-argument-validation-1.html).

The added test class ClassWithFunctionArguments would cause the tests to hang on the nondocumentedmethod function without the added keywords.