### PR TITLE
Last version compatible with Sphinx 3 and Python 2.X

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,17 @@
+sphinxcontrib-matlabdomain-0.11.8 (2021-05-12)
+==============================================
+
+*  Limit to Sphinx < 4.0.0, due to too many breaking changes.
+*  Last version to support Python 2.7
+
+
 sphinxcontrib-matlabdomain-0.11.7 (2021-02-24)
 ==============================================
 
 * Fixed `Issue 117 <https://github.com/sphinx-contrib/matlabdomain/issues/117>`_.
   Parsing errors due to `"..."`.  Fix `MatObject::_remove_line_continuations`
   to take MATLAB strings into account.
-  
+
 
 sphinxcontrib-matlabdomain-0.11.6 (2021-02-23)
 ==============================================

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,10 @@ The Python package must be installed with::
 
 In general, the usage is the same as for documenting Python code.
 
+For a Python 2 compatible version the package must be installed with::
+
+   pip install sphinxcontrib-matlabdomain==0.11.8
+
 Configuration
 -------------
 In your Sphinx ``conf.py`` file add ``sphinxcontrib.matlab`` to the list of

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 with open('README.rst', 'r') as f_readme:
     long_desc = f_readme.read()
 
-requires = ['Sphinx>=1.7.2', 'Pygments>=2.0.1', 'future>=0.16.0']
+requires = ['Sphinx>=1.7.2', 'Sphinx<4.0.0', 'Pygments>=2.0.1', 'future>=0.16.0']
 
 setup(
     name='sphinxcontrib-matlabdomain',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requires = ['Sphinx>=1.7.2', 'Sphinx<4.0.0', 'Pygments>=2.0.1', 'future>=0.16.0'
 setup(
     name='sphinxcontrib-matlabdomain',
     use_scm_version=True,
-    setup_requires=['setuptools_scm'],
+    setup_requires=['setuptools_scm<6.0.0'],
     url='https://github.com/sphinx-contrib/matlabdomain',
     download_url='http://pypi.python.org/pypi/sphinxcontrib-matlabdomain',
     license='BSD',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 with open('README.rst', 'r') as f_readme:
     long_desc = f_readme.read()
 
-requires = ['Sphinx>=1.7.2', 'Sphinx<4.0.0', 'Pygments>=2.0.1', 'future>=0.16.0']
+requires = ['Sphinx<4.0.0>=1.72', 'Pygments>=2.0.1', 'future>=0.16.0']
 
 setup(
     name='sphinxcontrib-matlabdomain',


### PR DESCRIPTION
Due to too many deprecated API's in Sphinx Docs (#118), this is the version to support Sphinx Docs version 3 and Python 2.x.