### PR TITLE
explicit parameter for paralell processing setting

### DIFF
--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -824,5 +824,5 @@ def setup(app):
     app.add_autodoc_attrgetter(doc.MatModule, doc.MatModule.getter)
     app.add_autodoc_attrgetter(doc.MatClass, doc.MatClass.getter)
 
-    return {'paralell_read_safe':False}
+    return {'parallel_read_safe':False}
     

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -823,3 +823,6 @@ def setup(app):
 
     app.add_autodoc_attrgetter(doc.MatModule, doc.MatModule.getter)
     app.add_autodoc_attrgetter(doc.MatClass, doc.MatClass.getter)
+
+    return {'paralell_read_safe':False}
+    


### PR DESCRIPTION
It seems like not explicitly  stating the parameter creates issues when docs are being created, as seen [here](https://github.com/ryanfox/sphinx-markdown-tables/issues/16)