### PR TITLE
Added support for long property docstring in classes

### DIFF
--- a/tests/test_data/ClassLongProperty.m
+++ b/tests/test_data/ClassLongProperty.m
@@ -1,0 +1,26 @@
+classdef ClassLongProperty
+    % test class property with long docstring
+    %
+    % :param a: the input to :class:`ClassExample`
+
+    properties
+		a  % short description
+        
+		% A property with a long documentation
+		% This is the second line
+		% And a third
+		b % a property
+
+        % This comment is not for property c
+        
+        c
+    end
+    methods
+        function b = get.b(a)
+			% Description of the property getter
+			% This is not rendered to be consistent with Matlab
+            b = 0;
+        end
+		end
+end
+

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -71,7 +71,7 @@ def test_module(mod):
                       'ClassWithUndocumentedMembers', 'ClassWithGetterSetter',
                       'ClassWithDoubleQuotedString', 'ClassWithDummyArguments',
                       'ClassWithStrings', 'ClassWithFunctionArguments', 'ClassWithMethodsWithSpaces',
-                      'ClassContainingParfor', 'ClassWithStringEllipsis'}
+                      'ClassContainingParfor', 'ClassWithStringEllipsis', 'ClassLongProperty'}
     assert all_items == expected_items
     assert mod.getter('__name__') in modules
 

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -559,6 +559,17 @@ def test_ClassWithStringEllipsis():
     assert obj.docstring == " Contains ellipsis in string\n"
 
 
+def test_ClassLongProperty():
+    mfile = os.path.join(TESTDATA_ROOT, 'ClassLongProperty.m')
+    obj = mat_types.MatObject.parse_mfile(mfile, 'ClassLongProperty', 'test_data')
+    assert obj.name == 'ClassLongProperty'
+    assert obj.docstring == " test class property with long docstring\n\n " \
+            ":param a: the input to :class:`ClassExample`\n"
+    assert obj.properties['a']['docstring'] == " short description"
+    assert obj.properties['b']['docstring'] == " A property with a long " \
+        "documentation\n This is the second line\n And a third\n"
+    assert obj.properties['c']['docstring'] is None
+
 
 if __name__ == '__main__':
     pytest.main([os.path.abspath(__file__)])


### PR DESCRIPTION
### Description of changes 

I have added support for multi-line comments that precede property declaration in classes. According to [Matlab's documentation](https://fr.mathworks.com/help/matlab/matlab_prog/create-help-for-classes.html):

> There are two ways to create help for properties:
> - Insert comment lines above the property definition. Use this approach for multiline help text.
> - Add a single-line comment next to the property definition.

I also added unit tests to probe the new feature.

### Issues solved:
Fixes #125 
Along the way, I think I also solved an issue where inline property docstrings were hidden if they were after a semicolon.

