### PR TITLE
Release 0.13.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+sphinxcontrib-matlabdomain-0.13.0 (2022-02-13)
+==============================================
+
+* Explicit set ``parallel_read_safe`` to ``False`` to avoid error in parallel
+  builds.
+* Fixed `Issue 125 <https://github.com/sphinx-contrib/matlabdomain/issues/125>`_.
+  Finally, we are able to support *long* docstrings for properties. It works as
+  the same as MATLAB. Comment lines above a ``property`` are now treated as
+  docstrings.
+
+
 sphinxcontrib-matlabdomain-0.12.0 (2021-06-12)
 ==============================================
 

--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,10 @@ Example: given the following MATLAB source in folder ``test_data``::
         %% some comments
         properties
             x % a property
+
+            % Multiple lines before a
+            % property can also be used
+            y
         end
         methods
             function h = MyHandleClass(x)

--- a/tests/test_data/ClassAbstract.m
+++ b/tests/test_data/ClassAbstract.m
@@ -8,7 +8,6 @@ classdef (Abstract = true, Sealed) ClassAbstract < ClassInheritHandle & ClassExa
         version = '0.1.1-beta' % version
     end
     properties (SetAccess = private, GetAccess = private)
-        %: one day this will work
         y % y variable
     end
     methods


### PR DESCRIPTION
* Explicit set `parallel_read_safe` to `False` to avoid error in parallel
  builds.
* Fixed #125 
  Finally, we are able to support *long* docstrings for properties. It works as
  the same as MATLAB. Comment lines above a ``property`` are now treated as
  docstrings.
