### PR TITLE
ENH: Implement MATLABDomain.resolve_any_xref

### DIFF
--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -763,6 +763,16 @@ class MATLABDomain(Domain):
         for refname, (docname, type) in self.data['objects'].items():
             yield (refname, refname, type, docname, refname, 1)
 
+    def resolve_any_xref(self, env, fromdocname, builder, target, node, contnode):
+        ret = []
+        for role in self.roles:
+            matrole = f'mat:{role}'
+            element = self.resolve_xref(env, fromdocname, builder,
+                                        matrole, target, node, contnode)
+            if element:
+                ret.append((matrole, element))
+        return ret
+
 
 def setup(app):
     app.add_domain(MATLABDomain)


### PR DESCRIPTION
There may be a more efficient way of doing this, but it seems like it should work. With some guidance I could write a test.

Closes #134.