### PR TITLE
Fix parsing of overloaded class parameters with validation functions

### DIFF
--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -896,12 +896,33 @@ class MatClass(MatMixin, MatObject):
                             
                         # subtype of Name EG Name.Builtin used as Name
                         elif self.tokens[idx][0] in Token.Name.subtypes:  # @UndefinedVariable
+                        
                             prop_name = self.tokens[idx][1]
                             warn_msg = ' '.join(['[%s] WARNING %s.%s.%s is',
                                                  'a Builtin Name'])
                             logger.debug(warn_msg, MAT_DOM, self.module, self.name, prop_name)
                             self.properties[prop_name] = {'attrs': attr_dict}
                             idx += 1
+                            
+                            # skip size, class and functions specifiers
+                            # TODO: Parse old and new style property extras
+                            while self._tk_eq(idx, (Token.Punctuation, '@')) or \
+                                  self._tk_eq(idx, (Token.Punctuation, '(')) or \
+                                  self._tk_eq(idx, (Token.Punctuation, ')')) or \
+                                  self._tk_eq(idx, (Token.Punctuation, ',')) or \
+                                  self._tk_eq(idx, (Token.Punctuation, ':')) or \
+                                  self.tokens[idx][0] == Token.Literal.Number.Integer or \
+                                  self._tk_eq(idx, (Token.Punctuation, '{')) or \
+                                  self._tk_eq(idx, (Token.Punctuation, '}')) or \
+                                  self._tk_eq(idx, (Token.Punctuation, '.')) or \
+                                  self.tokens[idx][0] == Token.Literal.String or \
+                                  self.tokens[idx][0] == Token.Name or \
+                                  self.tokens[idx][0] == Token.Text:
+                                idx += 1
+                                
+                            if self._tk_eq(idx, (Token.Punctuation, ';')):
+                                continue
+                            
                         elif self._tk_eq(idx, (Token.Keyword, 'end')):
                             idx += 1
                             break

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -946,8 +946,8 @@ class MatClass(MatMixin, MatObject):
                                 self.properties[prop_name]['docstring'] = docstring
                                 idx += 1
                         else:
-                            msg = '[sphinxcontrib-matlabdomain] Expected property - got %s' % str(self.tokens[idx])
-                            logger.warning(msg)
+                            msg = '[sphinxcontrib-matlabdomain] Expected property in %s.%s - got %s'
+                            logger.warning(msg, self.module, self.name, str(self.tokens[idx]))
                             return
                         idx += self._blanks(idx)  # skip blanks
                         # =========================================================

--- a/tests/test_data/ClassWithBuiltinProperties.m
+++ b/tests/test_data/ClassWithBuiltinProperties.m
@@ -1,0 +1,8 @@
+classdef ClassWithBuiltinProperties < handle
+    % Class with properties that overload a builtin
+    properties
+        omega (1,:) {mustBeText} % a property
+        alpha % a property overloading a builtin
+        gamma (1,:) {mustBeScalarOrEmpty} % a property overloading a builtin with validation
+    end
+end

--- a/tests/test_data/ClassWithBuiltinProperties.m
+++ b/tests/test_data/ClassWithBuiltinProperties.m
@@ -4,5 +4,6 @@ classdef ClassWithBuiltinProperties < handle
         omega (1,:) {mustBeText} % a property
         alpha % a property overloading a builtin
         gamma (1,:) {mustBeScalarOrEmpty} % a property overloading a builtin with validation
+        beta (1,:) {mustBeScalarOrEmpty} % another overloaded property
     end
 end

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -63,7 +63,7 @@ def test_module(mod):
                       'script_with_comment_header_4',
                       'PropTypeOld', 'ValidateProps', 'ClassWithMethodAttributes', 'ClassWithPropertyAttributes',
                       'ClassWithoutIndent', 'f_with_utf8', 'f_with_latin_1', 'f_with_name_mismatch',
-                      'ClassWithBuiltinOverload', 'ClassWithFunctionVariable',
+                      'ClassWithBuiltinOverload', 'ClassWithBuiltinProperties', 'ClassWithFunctionVariable',
                       'ClassWithErrors', 'f_inputargs_error',
                       'ClassWithAttributes', 'ClassWithLineContinuation',
                       'ClassWithUnknownAttributes', 'ClassWithNameMismatch',

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -350,6 +350,20 @@ def test_ClassWithBuiltinOverload():
     assert obj.docstring == " Class that overloads a builtin\n"
 
 
+def test_ClassWithBuiltinProperties():
+    mfile = os.path.join(DIRNAME, 'test_data', 'ClassWithBuiltinProperties.m')
+    obj = mat_types.MatObject.parse_mfile(mfile,
+                                          'ClassWithBuiltinProperties',
+                                          'test_data')
+    assert obj.name == 'ClassWithBuiltinProperties'
+    assert obj.docstring == " Class with properties that overload a builtin\n"
+    assert obj.properties['omega']['docstring'] == " a property"
+    assert obj.properties['alpha']['docstring'] == (
+                                        " a property overloading a builtin")
+    assert obj.properties['gamma']['docstring'] == (
+                        " a property overloading a builtin with validation")
+
+
 # Fails when running with other test files. Warnings are already logged.
 @pytest.mark.xfail
 def test_f_with_name_mismatch(caplog):

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -357,11 +357,14 @@ def test_ClassWithBuiltinProperties():
                                           'test_data')
     assert obj.name == 'ClassWithBuiltinProperties'
     assert obj.docstring == " Class with properties that overload a builtin\n"
+    assert set(obj.properties) == set(['omega', 'alpha', 'gamma', 'beta'])
     assert obj.properties['omega']['docstring'] == " a property"
     assert obj.properties['alpha']['docstring'] == (
                                         " a property overloading a builtin")
     assert obj.properties['gamma']['docstring'] == (
                         " a property overloading a builtin with validation")
+    assert obj.properties['beta']['docstring'] == (
+                                            " another overloaded property")
 
 
 # Fails when running with other test files. Warnings are already logged.


### PR DESCRIPTION
This PR fixes a bug that occurs if a MATLAB class has an overloaded parameter with validation functions, such as:

```matlab
classdef ClassWithBuiltinProperties < handle
    % Class with properties that overload a builtin
    properties
        omega (1,:) {mustBeText} % a property
        alpha % a property overloading a builtin
        gamma (1,:) {mustBeScalarOrEmpty} % a property overloading a builtin with validation
        beta (1,:) {mustBeScalarOrEmpty} % another overloaded property
    end
end
```

When parsing this class `MatClass` would stop reading after reaching the first '`(`' token, following the `gamma` parameter.

I've added a fix by copying the code [that skips the function identifiers for a non-overloading parameter name](https://github.com/sphinx-contrib/matlabdomain/blob/a87837a9d6361ad171364f4a2de416ac675116ed/sphinxcontrib/mat_types.py#L878-L895).

I've also improved the warning generated in this situation by adding the module and class name to it, as it was hard to track down where the problem was coming from.
 