### PR TITLE
Support Pygments >= 2.14.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Run tests and build test documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+        architecture: x64
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,6 +8,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Run tests and build test documentation
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,10 +8,10 @@ on: [push, pull_request]
 jobs:
   test:
     name: Run tests and build test documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ sphinxcontrib-matlabdomain-0.15.0 (2023-01-02)
 
 * Pygments >= 2.14.0 is now supported. Pygments tokenization changed to return
   ``Token.Text.WhiteSpace`` for newline characters. This resulted in a infinite
-  loop when parsing through MATLAB files.
+  loop when parsing MATLAB files.
 
 
 sphinxcontrib-matlabdomain-0.14.1 (2022-09-02)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+sphinxcontrib-matlabdomain-0.15.0 (2023-01-02)
+==============================================
+
+* Pygments >= 2.14.0 is now supported. Pygments tokenization changed to return
+  ``Token.Text.WhiteSpace`` for newline characters. This resulted in a infinite
+  loop when parsing through MATLAB files.
+
+
 sphinxcontrib-matlabdomain-0.14.1 (2022-09-02)
 ==============================================
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ The Python package must be installed with::
    pip install -U sphinxcontrib-matlabdomain
 
 In general, the usage is the same as for documenting Python code. The package
-requires Python >= 3.6 and Sphinx >= 4.0.0.
+is tested with Python >= 3.8 and Sphinx >=4.0.0 and <6.0.0.
 
 For a Python 2 compatible version the package must be installed with::
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 with open('README.rst', 'r') as f_readme:
     long_desc = f_readme.read()
 
-requires = ['Sphinx>=4.0.0', 'Pygments>=2.0.1', 'future>=0.16.0']
+requires = ['Sphinx>=4.0.0', 'Sphinx<6.0.0', 'Pygments>=2.0.1', 'future>=0.16.0']
 
 setup(
     name='sphinxcontrib-matlabdomain',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 with open('README.rst', 'r') as f_readme:
     long_desc = f_readme.read()
 
-requires = ['Sphinx>=4.0.0', 'Sphinx<6.0.0', 'Pygments>=2.0.1', 'future>=0.16.0']
+requires = ['Sphinx>=4.0.0', 'Pygments>=2.0.1']
 
 setup(
     name='sphinxcontrib-matlabdomain',

--- a/sphinxcontrib/mat_directives.py
+++ b/sphinxcontrib/mat_directives.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from sphinx.ext.autodoc.directive import AutodocDirective, DummyOptionSpec, DocumenterBridge
 from sphinx.ext.autodoc.directive import process_documenter_options, parse_generated_content
 import sphinx.util
@@ -42,8 +41,8 @@ class MatlabAutodocDirective(AutodocDirective):
                          (self.name, exc), location=(source, lineno))
             return []
 
-        # generate the output        
-        params = DocumenterBridge(self.env, reporter, documenter_options, lineno, self.state)        
+        # generate the output
+        params = DocumenterBridge(self.env, reporter, documenter_options, lineno, self.state)
         documenter = doccls(params, self.arguments[0])
         documenter.generate(more_content=self.content)
         if not params.result:

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -8,8 +8,6 @@
     :copyright: Copyright 2014 Mark Mikofski
     :license: BSD, see LICENSE for details.
 """
-from __future__ import unicode_literals
-
 from .mat_types import (MatModule, MatObject, MatFunction, MatClass, MatProperty,
                         MatMethod, MatScript, MatException, MatModuleAnalyzer,
                         MatApplication, modules)
@@ -69,7 +67,7 @@ class MatlabDocumenter(PyDocumenter):
         try:
             explicit_modname, path, base, args, retann = \
                  mat_ext_sig_re.match(self.name).groups()
-        except AttributeError:            
+        except AttributeError:
             self.directive.warn('invalid signature for auto%s (%r)' %
                                 (self.objtype, self.name))
             return False
@@ -135,7 +133,7 @@ class MatlabDocumenter(PyDocumenter):
                 errmsg = '[sphinxcontrib-matlabdomain]: failed to import %s %r' % \
                          (self.objtype, self.fullname)
             errmsg += '; the following exception was raised:\n%s' % \
-                      traceback.format_exc()            
+                      traceback.format_exc()
             logger.warning(errmsg)
             self.env.note_reread()
             return False
@@ -163,7 +161,7 @@ class MatlabDocumenter(PyDocumenter):
             sourcename = 'docstring of %s' % self.fullname
 
         # add content from docstrings
-        if not no_docstring:            
+        if not no_docstring:
             docstrings = self.get_doc()
             if not docstrings:
                 # append at least a dummy docstring, so that the event

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2014 Mark Mikofski
     :license: BSD, see LICENSE for details.
 """
-from __future__ import unicode_literals
 from io import open  # for opening files with encoding in Python 2
 import os
 import re

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -477,7 +477,8 @@ class MatMixin(object):
         :type idx: int
         """
         idx0 = idx  # original index
-        while (self.tokens[idx][0] is Token.Text and
+        while ((self.tokens[idx][0] is Token.Text or
+                self.tokens[idx][0] is Token.Text.WhiteSpace) and
                self.tokens[idx][1] in [' ', '\n', '\t']):
             idx += 1
         return idx - idx0  # whitespace
@@ -829,44 +830,44 @@ class MatClass(MatMixin, MatObject):
                                 idx += whitespace
                             else:
                                 idx += 1
-                                
+
                         # =========================================================
                         # long docstring before property
                         if self.tokens[idx][0] is Token.Comment:
                             # docstring
                             docstring = ''
-                            
+
                             # Collect comment lines
                             while self.tokens[idx][0] is Token.Comment:
                                 docstring += self.tokens[idx][1].lstrip('%')
-                                idx += 1 
+                                idx += 1
                                 idx += self._blanks(idx)
-                                
+
                                 try:
                                     # Check if end of line was reached
                                     if self.tokens[idx][0] == Token.Text and self.tokens[idx][1] == '\n':
                                         docstring += '\n'
                                         idx += 1
                                         idx += self._blanks(idx)
-                                        
-                                    # Check if variable name is next                                        
+
+                                    # Check if variable name is next
                                     if self.tokens[idx][0] is Token.Name:
                                         prop_name = self.tokens[idx][1]
                                         self.properties[prop_name] = {'attrs': attr_dict}
                                         self.properties[prop_name]['docstring'] = docstring
                                         break
-                                    
-                                    # If there is an empty line at the end of 
+
+                                    # If there is an empty line at the end of
                                     # the comment: discard it
                                     elif self.tokens[idx][0] == Token.Text and self.tokens[idx][1] == '\n':
                                         docstring = ''
                                         idx += self._whitespace(idx)
                                         break
-                                    
+
                                 except IndexError:
                                     # EOF reached, quit gracefully
-                                    break    
-                            
+                                    break
+
                         # with "%:" directive trumps docstring after property
                         if self.tokens[idx][0] is Token.Name:
                             prop_name = self.tokens[idx][1]
@@ -890,20 +891,20 @@ class MatClass(MatMixin, MatObject):
                                   self.tokens[idx][0] == Token.Name or \
                                   self.tokens[idx][0] == Token.Text:
                                 idx += 1
-                                
+
                             if self._tk_eq(idx, (Token.Punctuation, ';')):
                                 continue
-                            
+
                         # subtype of Name EG Name.Builtin used as Name
                         elif self.tokens[idx][0] in Token.Name.subtypes:  # @UndefinedVariable
-                        
+
                             prop_name = self.tokens[idx][1]
                             warn_msg = ' '.join(['[%s] WARNING %s.%s.%s is',
                                                  'a Builtin Name'])
                             logger.debug(warn_msg, MAT_DOM, self.module, self.name, prop_name)
                             self.properties[prop_name] = {'attrs': attr_dict}
                             idx += 1
-                            
+
                             # skip size, class and functions specifiers
                             # TODO: Parse old and new style property extras
                             while self._tk_eq(idx, (Token.Punctuation, '@')) or \
@@ -919,10 +920,10 @@ class MatClass(MatMixin, MatObject):
                                   self.tokens[idx][0] == Token.Name or \
                                   self.tokens[idx][0] == Token.Text:
                                 idx += 1
-                                
+
                             if self._tk_eq(idx, (Token.Punctuation, ';')):
                                 continue
-                            
+
                         elif self._tk_eq(idx, (Token.Keyword, 'end')):
                             idx += 1
                             break
@@ -938,7 +939,7 @@ class MatClass(MatMixin, MatObject):
                                     self.properties[prop_name]['default'] = None
                                 if 'docstring' not in self.properties[prop_name].keys():
                                     self.properties[prop_name]['docstring'] = None
-                                                                         
+
                                 continue
                             elif self.tokens[idx][0] is Token.Comment:
                                 docstring = self.tokens[idx][1].lstrip('%')
@@ -1008,7 +1009,7 @@ class MatClass(MatMixin, MatObject):
                         elif self.tokens[idx][0] is Token.Comment:
                             # skip this comment
                             idx += 1
-                                
+
                         idx += self._whitespace(idx)
                     idx += 1
                 # =================================================================

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2011 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import, unicode_literals
 from . import mat_documenters as doc
 from . import mat_directives
 
@@ -737,7 +736,7 @@ class MATLABDomain(Domain):
         elif len(matches) > 1:
             logger.warning('[sphinxcontrib-matlabdomain] more than one target found for cross-reference %r: %s',
                            target, ', '.join(match[0] for match in matches), type='ref', subtype='python', location=node)
-                
+
         name, obj = matches[0]
 
         if obj[1] == 'module':
@@ -835,4 +834,3 @@ def setup(app):
     app.add_autodoc_attrgetter(doc.MatClass, doc.MatClass.getter)
 
     return {'parallel_read_safe':False}
-    

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import unicode_literals
 import pickle
 import os
 import sys

--- a/tests/test_docs/conf.py
+++ b/tests/test_docs/conf.py
@@ -11,7 +11,6 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-from __future__ import unicode_literals
 import sys
 import os
 

--- a/tests/test_duplicated_link.py
+++ b/tests/test_duplicated_link.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import unicode_literals
 import pickle
 import os
 import sys
@@ -37,12 +36,12 @@ def test_with_prefix(make_app, rootdir):
 
     assert isinstance(content[0], docutils.nodes.section)
     section = content[0][7]
-    assert section.astext() == 'NiceFiniteGroup\n\n\n\nclass +replab.NiceFiniteGroup\n\nBases: +replab.FiniteGroup\n\nA nice finite group is a finite group equipped with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv'    
+    assert section.astext() == 'NiceFiniteGroup\n\n\n\nclass +replab.NiceFiniteGroup\n\nBases: +replab.FiniteGroup\n\nA nice finite group is a finite group equipped with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv'
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_without_prefix(make_app, rootdir):
-    srcdir = rootdir / 'roots' / 'test_duplicate_link'    
+    srcdir = rootdir / 'roots' / 'test_duplicate_link'
     confdict = { 'matlab_keep_package_prefix' : False }
     app = make_app(srcdir=srcdir, confoverrides=confdict)
     app.builder.build_all()
@@ -51,7 +50,7 @@ def test_without_prefix(make_app, rootdir):
 
     assert isinstance(content[0], docutils.nodes.section)
     section = content[0][7]
-    assert section.astext() == 'NiceFiniteGroup\n\n\n\nclass replab.NiceFiniteGroup\n\nBases: replab.FiniteGroup\n\nA nice finite group is a finite group equipped with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv'    
+    assert section.astext() == 'NiceFiniteGroup\n\n\n\nclass replab.NiceFiniteGroup\n\nBases: replab.FiniteGroup\n\nA nice finite group is a finite group equipped with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv'
 
 
 if __name__ == '__main__':

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, unicode_literals
 from sphinxcontrib.mat_lexer import MatlabLexer, Token
 
 

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -4,11 +4,11 @@ from sphinxcontrib.mat_lexer import MatlabLexer, Token
 def test_strings():
     tokens = list(MatlabLexer().get_tokens("'happy'\"happy\""))
     assert tokens[0:2] == [(Token.Literal.String, "'"), (Token.Literal.String, "happy'")]
-    assert tokens[2:4] == [(Token.Literal.String, '"happy"'), (Token.Text, '\n')]
+    assert tokens[2:3] == [(Token.Literal.String, '"happy"')] # Ignore whitespace
 
     tokens = list(MatlabLexer().get_tokens('"happy"\'happy\''))
     assert tokens[0:2] == [(Token.Literal.String, '"happy"'), (Token.Literal.String, "'")]
-    assert tokens[2:4] == [(Token.Literal.String, "happy'"), (Token.Text, '\n')]
+    assert tokens[2:3] == [(Token.Literal.String, "happy'")] # Ignore whitespace
 
 
 def test_function_names():

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 from sphinxcontrib import mat_documenters as doc
 from sphinxcontrib.mat_types import modules
 import os

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -151,7 +151,6 @@ def test_class_method(mod):
     assert mymethod.args[-1] == 'b'
     assert mymethod.retv == ['c']
     assert mymethod.docstring == " a method in :class:`ClassExample`\n\n :param b: an input to :meth:`mymethod`\n"
-    return cls_meth, constructor, mymethod
 
 
 def test_submodule_class(mod):

--- a/tests/test_package_links.py
+++ b/tests/test_package_links.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import unicode_literals
 import pickle
 import os
 import sys

--- a/tests/test_package_prefix.py
+++ b/tests/test_package_prefix.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2019 by the Isaac Lenton.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import unicode_literals
 import pickle
 import os
 import sys

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 from sphinxcontrib import mat_types
 import os
 import pytest
@@ -393,7 +392,7 @@ def test_f_with_string_ellipsis():
     mfile = os.path.join(DIRNAME, 'test_data', 'f_with_string_ellipsis.m')
     obj = mat_types.MatObject.parse_mfile(mfile, 'f_with_string_ellipsis', 'test_data')
     assert obj.name == 'f_with_string_ellipsis'
-    assert obj.docstring == " A function with a string with ellipsis\n"    
+    assert obj.docstring == " A function with a string with ellipsis\n"
 
 
 def test_ClassWithFunctionVariable():
@@ -554,7 +553,7 @@ def test_ClassWithMethodsWithSpaces():
     obj = mat_types.MatObject.parse_mfile(mfile, 'ClassWithMethodsWithSpaces', 'test_data')
     assert isinstance(obj, mat_types.MatClass)
     assert obj.name == 'ClassWithMethodsWithSpaces'
-    assert set(obj.methods.keys()) == set(['static_method'])       
+    assert set(obj.methods.keys()) == set(['static_method'])
     assert obj.docstring == " Class with methods that have space after the function name.\n"
     assert obj.methods['static_method'].attrs == {'Static': True}
 
@@ -563,7 +562,7 @@ def test_ClassContainingParfor():
     obj = mat_types.MatObject.parse_mfile(mfile, 'ClassContainingParfor', 'test_data')
     assert isinstance(obj, mat_types.MatClass)
     assert obj.name == 'ClassContainingParfor'
-    assert set(obj.methods.keys()) == set(['test'])       
+    assert set(obj.methods.keys()) == set(['test'])
     assert obj.docstring == " Parfor is a keyword\n"
 
 
@@ -572,7 +571,7 @@ def test_ClassWithStringEllipsis():
     obj = mat_types.MatObject.parse_mfile(mfile, 'ClassWithStringEllipsis', 'test_data')
     assert isinstance(obj, mat_types.MatClass)
     assert obj.name == 'ClassWithStringEllipsis'
-    assert set(obj.methods.keys()) == set(['test'])       
+    assert set(obj.methods.keys()) == set(['test'])
     assert obj.docstring == " Contains ellipsis in string\n"
 
 

--- a/tests/test_pymat.py
+++ b/tests/test_pymat.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import unicode_literals
 import pickle
 import os
 import sys

--- a/tests/test_pymat_common_root.py
+++ b/tests/test_pymat_common_root.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import unicode_literals
 import pickle
 import os
 import sys


### PR DESCRIPTION
* Updated to support Pygments >= 2.14.0
* Removed imports of `future`. We only support Python 3.
* Updated tests to run on versions: "3.8", "3.9", "3.10", "3.11".