### PR TITLE
Add a test project for skipping module members

### DIFF
--- a/tests/roots/test_skipping_module_members/Makefile
+++ b/tests/roots/test_skipping_module_members/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/tests/roots/test_skipping_module_members/conf.py
+++ b/tests/roots/test_skipping_module_members/conf.py
@@ -1,0 +1,34 @@
+import os
+
+project = 'Skipping Members'
+copyright = '2023, Jørgen Cederberg'
+author = 'Jørgen Cederberg'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = []
+matlab_src_dir = os.path.abspath('.')
+
+extensions = ['sphinx.ext.autodoc', 'sphinxcontrib.matlab']
+primary_domain = 'mat'
+master_doc = 'index'
+
+# The suffix of source filenames.
+source_suffix = '.rst'
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']
+
+def skip_second(app, what, name, obj, skip, options):
+    print(f"{app}, {what}, {name}, {obj}, {skip}, {options}")
+    return name == "second"
+
+def setup(app):
+    app.connect('autodoc-skip-member', skip_second)

--- a/tests/roots/test_skipping_module_members/index.rst
+++ b/tests/roots/test_skipping_module_members/index.rst
@@ -1,0 +1,2 @@
+.. automodule:: src
+   :members:

--- a/tests/roots/test_skipping_module_members/make.bat
+++ b/tests/roots/test_skipping_module_members/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/tests/roots/test_skipping_module_members/src/first.m
+++ b/tests/roots/test_skipping_module_members/src/first.m
@@ -1,0 +1,3 @@
+function y = first(x)
+% The first function
+y = x;

--- a/tests/roots/test_skipping_module_members/src/second.m
+++ b/tests/roots/test_skipping_module_members/src/second.m
@@ -1,0 +1,3 @@
+function y = second(x)
+% The second function
+y = x;

--- a/tests/test_skipping_module_members.py
+++ b/tests/test_skipping_module_members.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+    test_autodoc
+    ~~~~~~~~~~~~
+
+    Test the autodoc extension.
+
+    :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+import pickle
+import os
+import sys
+
+import pytest
+
+from sphinx import addnodes
+from sphinx.testing.fixtures import make_app, test_params   # noqa: F811;
+from sphinx.testing.path import path
+
+
+@pytest.fixture(scope='module')
+def rootdir():
+    return path(os.path.dirname(__file__)).abspath()
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_setup(make_app, rootdir):
+    srcdir = rootdir / 'roots' / 'test_skipping_module_members'
+    app = make_app(srcdir=srcdir)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / 'index.doctree').read_bytes())
+    content_text = content.astext()
+    assert 'The first function' in content_text
+    assert 'The second function' not in content_text
+
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
The project `tests/roots/test_skipping_module_members` demonstrates how to use the `'autodoc-skip-member'´ feature.