### PR TITLE
Expand testing to multiple versions of Sphinx

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         sphinx-version: ["40", "41", "42", "43", "44", "45", "50", "51", "52", "60", "latest"]
-      runs-on: ${{ matrix.python-version }}
+    runs-on: ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,15 +7,13 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Run tests and build test documentation
+    name: Run tests for Python ${{ matrix.python-version }} and Sphinx ${{ matrix.sphinx-version }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         sphinx-version: ["45", "53", "60", "latest"]
-
-
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -27,13 +25,27 @@ jobs:
       run: |
         pip install tox
         tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}"
+
+  check:
+    name: Run static analysis
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+        architecture: x64
     - name: Lint with flake8
       run: |
         pip install flake8
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 sphinxcontrib --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 tests --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --exclude .git,__pycache__,.eggs --max-complexity=10 --max-line-length=127 --statistics
+        flake8 sphinxcontrib --count --exit-zero --exclude .git,__pycache__,.eggs --max-complexity=10 --max-line-length=127 --statistics
+        flake8 tests --count --exit-zero --exclude .git,__pycache__,.eggs --max-complexity=10 --max-line-length=127 --statistics
 
 
   build-n-publish:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        sphinx-version: ${{ matrix.sphinx-version }}
         architecture: x64
     - name: Run with Tox
       env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,9 +26,9 @@ jobs:
     - name: Run with Tox
       run: |
         echo ${{ matrix.sphinx-version}}
-        python -m pip install --upgrade pip
         pip install tox
         tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}"
+        tox -e docs
     # - name: Lint with flake8
     #   run: |
     #     # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,16 +23,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: x64
     - name: Run with Tox
-      env:
-        SPHINXVERSION: matrix.sphinx-version
-        TOXENV: "${{ matrix.python-version }}-sphinx$SPHINXVERSION"
       run: |
-        TOXENV=${{ env.TOXENV }}
-        TOXENV=${TOXENV//.} # replace all dots
-        echo TOXENV=${TOXENV} >> $GITHUB_ENV # update GitHub ENV vars
+        echo ${{ matrix.sphinx-version}}
         python -m pip install --upgrade pip
         pip install tox
-        tox -e "$TOXENV"
+        tox -e "${{matrix.python-version}}-sphinx60"
     # - name: Lint with flake8
     #   run: |
     #     # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,17 +14,6 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         sphinx-version: ["45", "53", "60", "latest"]
-        exclude:
-          - python-version: "3.11"
-            sphinx-version: "45"
-          - python-version: "3.8"
-            sphinx-version: "60"
-          - python-version: "3.8"
-            sphinx-version: "latest"
-          - python-version: "3.9"
-            sphinx-version: "60"
-          - python-version: "3.8"
-            sphinx-version: "latest"
 
 
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,11 +25,11 @@ jobs:
         architecture: x64
     - name: Run with Tox
       run: |
-        echo ${{ matrix.sphinx-version}}
         pip install tox
         tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}"
     - name: Lint with flake8
       run: |
+        pip install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,19 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        sphinx-version: ["40", "41", "42", "43", "44", "45", "50", "51", "52", "60", "latest"]
+        sphinx-version: ["45", "53", "60", "latest"]
+        exclude:
+          - python-version: "3.11"
+            sphinx-version: "45"
+          - python-version: "3.8"
+            sphinx-version: "60"
+          - python-version: "3.8"
+            sphinx-version: "latest"
+          - python-version: "3.9"
+            sphinx-version: "60"
+          - python-version: "3.8"
+            sphinx-version: "latest"
+
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,16 +14,17 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         sphinx-version: ["40", "41", "42", "43", "44", "45", "50", "51", "52", "60", "latest"]
-    runs-on: ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        sphinx-version: ${{ matrix.sphinx-version }}
+        python-version: ${{ matrix.python-version }}
         architecture: x64
     - name: Run with Tox
+      with:
+        sphinx-version: ${{ matrix.sphinx-version }}
       env:
         TOXENV: "${{ matrix.python-version }}-sphinx{{ matrix.sphinx-version }}"
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
         echo ${{ matrix.sphinx-version}}
         python -m pip install --upgrade pip
         pip install tox
-        tox -e "${{matrix.python-version}}-sphinx60"
+        tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}"
     # - name: Lint with flake8
     #   run: |
     #     # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run with Tox
       run: |
         echo ${{ matrix.sphinx-version}}
-        pip install tox~=3.27
+        pip install tox
         tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}"
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        sphinx-version: ["40", "41", "42", "43", "44", "45", "50", "51", "52", "60", "latest"]
 
     steps:
     - uses: actions/checkout@v3
@@ -21,23 +22,28 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
-    - name: Install dependencies
+    - name: Run with Tox
+      env:
+        TOXENV: "${{ matrix.python-version }}-sphinx{{ matrix.sphinx-version }}"
       run: |
+        TOXENV=${{ env.TOXENV }}
+        TOXENV=${TOXENV//.} # replace all dots
+        echo TOXENV=${TOXENV} >> $GITHUB_ENV # update GitHub ENV vars
         python -m pip install --upgrade pip
-        pip install flake8 pytest pytest-cov
-        pip install -r dev-requirements.txt        
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --exclude .git,__pycache__,.eggs --max-complexity=10 --max-line-length=127 --statistics
-    - name: Run tests
-      run: pytest tests
-    - name: Build test docs
-      run: |
-        cd tests/test_docs
-        sphinx-build -b html . _build
+        pip install tox
+        tox -e "$TOXENV"
+    # - name: Lint with flake8
+    #   run: |
+    #     # stop the build if there are Python syntax errors or undefined names
+    #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+    #     flake8 . --count --exit-zero --exclude .git,__pycache__,.eggs --max-complexity=10 --max-line-length=127 --statistics
+    # - name: Run tests
+    #   run: pytest tests
+    # - name: Build test docs
+    #   run: |
+    #     cd tests/test_docs
+    #     sphinx-build -b html . _build
 
   build-n-publish:
     if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,21 +26,15 @@ jobs:
     - name: Run with Tox
       run: |
         echo ${{ matrix.sphinx-version}}
-        pip install tox
+        pip install tox~=3.27
         tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}"
-        tox -e docs
-    # - name: Lint with flake8
-    #   run: |
-    #     # stop the build if there are Python syntax errors or undefined names
-    #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-    #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-    #     flake8 . --count --exit-zero --exclude .git,__pycache__,.eggs --max-complexity=10 --max-line-length=127 --statistics
-    # - name: Run tests
-    #   run: pytest tests
-    # - name: Build test docs
-    #   run: |
-    #     cd tests/test_docs
-    #     sphinx-build -b html . _build
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --exclude .git,__pycache__,.eggs --max-complexity=10 --max-line-length=127 --statistics
+
 
   build-n-publish:
     if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,13 +14,13 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         sphinx-version: ["40", "41", "42", "43", "44", "45", "50", "51", "52", "60", "latest"]
+      runs-on: ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
         sphinx-version: ${{ matrix.sphinx-version }}
         architecture: x64
     - name: Run with Tox

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,10 +23,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: x64
     - name: Run with Tox
-      with:
-        sphinx-version: ${{ matrix.sphinx-version }}
       env:
-        TOXENV: "${{ matrix.python-version }}-sphinx{{ matrix.sphinx-version }}"
+        SPHINXVERSION: matrix.sphinx-version
+        TOXENV: "${{ matrix.python-version }}-sphinx$SPHINXVERSION"
       run: |
         TOXENV=${{ env.TOXENV }}
         TOXENV=${TOXENV//.} # replace all dots

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs, py{38,39,310,311}-sphinx{45,53,60,latest}
+envlist = py{38,39,310,311}-sphinx{45,53,60,latest}
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{36,37,38,39}-sphinx{17,18,20,21,22,23,24,30,31,32,33,34,35,40,41,42,43,44,45,50,51,52}
+    py{36,37,38,39}-sphinx{45,53}
     # Python 3.10 working from Sphinx 4.2 and up
-    py{310}-sphinx{42,43,44,45,50,51,52,53,latest}
+    py{310}-sphinx{45,53,latest}
     # Sphinx 6+ has simplified docutils and Python support
     py{38,39,10}-sphinx{60}
     # Python 3.11 working from Sphinx 5.3 and up
@@ -12,38 +12,9 @@ envlist =
 deps =
     .
     pytest
-    sphinx17: Sphinx>=1.7,<1.8
-    sphinx18: Sphinx>=1.8,<1.9
-    sphinx20: Sphinx>=2.0,<2.1
-    sphinx21: Sphinx>=2.1,<2.2
-    sphinx22: Sphinx>=2.2,<2.3
-    sphinx23: Sphinx>=2.3,<2.4
-    sphinx24: Sphinx>=2.4,<2.5
-    sphinx30: Sphinx>=3.0,<3.1
-    sphinx31: Sphinx>=3.1,<3.2
-    sphinx32: Sphinx>=3.2,<3.3
-    sphinx33: Sphinx>=3.3,<3.4
-    sphinx34: Sphinx>=3.4,<3.5
-    sphinx35: Sphinx>=3.5,<3.6
-    sphinx40: Sphinx>=4.0,<4.1
-    sphinx41: Sphinx>=4.1,<4.2
-    sphinx42: Sphinx>=4.2,<4.3
-    sphinx43: Sphinx>=4.3,<4.4
-    sphinx44: Sphinx>=4.4,<4.5
     sphinx45: Sphinx>=4.5,<4.6
-    sphinx50: Sphinx>=5.0,<5.1
-    sphinx51: Sphinx>=5.1,<5.2
-    sphinx52: Sphinx>=5.2,<5.3
     sphinx53: Sphinx>=5.3,<5.4
     sphinx60: Sphinx>=6.0,<6.1
-    # All these Sphinx versions actually break since docutils 0.18, so we need to add this upper bound
-    # Projects using these Sphinx versions will have to do the same
-    # See: https://github.com/readthedocs/sphinx_rtd_theme/pull/1304
-    sphinx{17,18,20,21,22,23,24,30,31,32,33,34,35,40,41,42}: docutils<0.18
-    # External environments are required to add this dependency for older versions of Sphinx
-    # because it didn't ship with this upper bound.
-    # See: https://github.com/sphinx-doc/sphinx/issues/10291
-    sphinx{17,18,20,21,22,23,24,30,31,32,33,34,35,40}: Jinja2<3.1
     sphinxlatest: Sphinx
     sphinxdev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
 commands =
@@ -52,4 +23,4 @@ commands =
     ## test links
     #sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees doc {envtmpdir}/linkcheck
     ## test html output
-    sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+    #sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,55 @@
 [tox]
-envlist = py36,py37,p38,py39
+envlist =
+    py{36,37,38,39}-sphinx{17,18,20,21,22,23,24,30,31,32,33,34,35,40,41,42,43,44,45,50,51,52}
+    # Python 3.10 working from Sphinx 4.2 and up
+    py{310}-sphinx{42,43,44,45,50,51,52,53,latest}
+    # Sphinx 6+ has simplified docutils and Python support
+    py{38,39,10}-sphinx{60}
+    # Python 3.11 working from Sphinx 5.3 and up
+    py{311}-sphinx{53,60,latest}
 
 [testenv]
 deps =
+    .
     pytest
+    sphinx17: Sphinx>=1.7,<1.8
+    sphinx18: Sphinx>=1.8,<1.9
+    sphinx20: Sphinx>=2.0,<2.1
+    sphinx21: Sphinx>=2.1,<2.2
+    sphinx22: Sphinx>=2.2,<2.3
+    sphinx23: Sphinx>=2.3,<2.4
+    sphinx24: Sphinx>=2.4,<2.5
+    sphinx30: Sphinx>=3.0,<3.1
+    sphinx31: Sphinx>=3.1,<3.2
+    sphinx32: Sphinx>=3.2,<3.3
+    sphinx33: Sphinx>=3.3,<3.4
+    sphinx34: Sphinx>=3.4,<3.5
+    sphinx35: Sphinx>=3.5,<3.6
+    sphinx40: Sphinx>=4.0,<4.1
+    sphinx41: Sphinx>=4.1,<4.2
+    sphinx42: Sphinx>=4.2,<4.3
+    sphinx43: Sphinx>=4.3,<4.4
+    sphinx44: Sphinx>=4.4,<4.5
+    sphinx45: Sphinx>=4.5,<4.6
+    sphinx50: Sphinx>=5.0,<5.1
+    sphinx51: Sphinx>=5.1,<5.2
+    sphinx52: Sphinx>=5.2,<5.3
+    sphinx53: Sphinx>=5.3,<5.4
+    sphinx60: Sphinx>=6.0,<6.1
+    # All these Sphinx versions actually break since docutils 0.18, so we need to add this upper bound
+    # Projects using these Sphinx versions will have to do the same
+    # See: https://github.com/readthedocs/sphinx_rtd_theme/pull/1304
+    sphinx{17,18,20,21,22,23,24,30,31,32,33,34,35,40,41,42}: docutils<0.18
+    # External environments are required to add this dependency for older versions of Sphinx
+    # because it didn't ship with this upper bound.
+    # See: https://github.com/sphinx-doc/sphinx/issues/10291
+    sphinx{17,18,20,21,22,23,24,30,31,32,33,34,35,40}: Jinja2<3.1
+    sphinxlatest: Sphinx
+    sphinxdev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
 commands =
-    pytest tests
-
-[testenv:docs]
-changedir=tests/test_docs
-deps= sphinx
-commands=
-;    ## test links
-;    #sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees doc {envtmpdir}/linkcheck
-;    ## test html output
+    pytest {posargs} tests/
+    cd tests/test_docs
+    ## test links
+    #sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees doc {envtmpdir}/linkcheck
+    ## test html output
     sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ deps =
     sphinxdev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
 commands =
     pytest {posargs} tests/
-    cd tests/test_docs
     ## test links
     #sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees doc {envtmpdir}/linkcheck
     ## test html output

--- a/tox.ini
+++ b/tox.ini
@@ -13,23 +13,4 @@ deps =
     sphinxdev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
 commands =
     pytest {posargs} tests/
-
-
-[testenv:docs]
-change_dir=
-    tests/test_docs
-deps =
-    .
-    sphinx45: Sphinx>=4.5,<4.6
-    sphinx53: Sphinx>=5.3,<5.4
-    sphinx60: Sphinx>=6.0,<6.1
-    sphinxlatest: Sphinx
-    sphinxdev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
-commands =
-    sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
-
-
-    ## test links
-    #sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees doc {envtmpdir}/linkcheck
-    ## test html output
-    #sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+    sphinx-build -b html -d {envtmpdir}/doctrees tests/test_docs {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist =
-    py{38,39,310,311}-sphinx{45,53,60,latest}
+envlist = docs, py{38,39,310,311}-sphinx{45,53,60,latest}
 
 
 [testenv]
@@ -14,6 +13,22 @@ deps =
     sphinxdev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
 commands =
     pytest {posargs} tests/
+
+
+[testenv:docs]
+change_dir=
+    tests/test_docs
+deps =
+    .
+    sphinx45: Sphinx>=4.5,<4.6
+    sphinx53: Sphinx>=5.3,<5.4
+    sphinx60: Sphinx>=6.0,<6.1
+    sphinxlatest: Sphinx
+    sphinxdev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
+commands =
+    sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+
+
     ## test links
     #sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees doc {envtmpdir}/linkcheck
     ## test html output

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,7 @@
 [tox]
 envlist =
-    py{36,37,38,39}-sphinx{45,53}
-    # Python 3.10 working from Sphinx 4.2 and up
-    py{310}-sphinx{45,53,latest}
-    # Sphinx 6+ has simplified docutils and Python support
-    py{38,39,10}-sphinx{60}
-    # Python 3.11 working from Sphinx 5.3 and up
-    py{311}-sphinx{53,60,latest}
+    py{38,39,310,311}-sphinx{45,53,60,latest}
+
 
 [testenv]
 deps =


### PR DESCRIPTION
Prior we only tested on the latest version of Sphinx.
We now test in a matrix of:
* Python 3.8, 3.9, 3.10 and 3.11
* Sphinx 4.5, 5.3, 6.0 and Latest