### PR TITLE
Add new option: `matlab_show_property_default_value`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,13 +57,19 @@ Additional Configuration
 
 ``matlab_src_encoding``
    The encoding of the MATLAB files. By default, the files will be read as utf-8
-   and parsing errors will be replaced using ? chars.
+   and parsing errors will be replaced using ? chars. *Added in Version 0.9.0.*
 
 ``matlab_keep_package_prefix``
    Determines if the MATLAB package prefix ``+`` is displayed in the
-   generated documentation.  Default is true.  When false, packages are
+   generated documentation.  Default is ``True``.  When ``False``, packages are
    still referred to in ReST using ``+pakage.+subpkg.func`` but the output
-   will be ``pakage.other.func()``.
+   will be ``pakage.other.func()``. *Added in Version
+   0.11.0.*
+
+``matlab_show_property_default_value``
+   Show property default values in the rendered document. Default is ``False``,
+   which is what MathWorks does in their documentation. *Added in Version
+   0.16.0.*
 
 For convenience the `primary domain <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-primary_domain>`_
 can be set to ``mat``.

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -958,7 +958,12 @@ class MatAttributeDocumenter(MatClassLevelDocumenter):
                 except ValueError:
                     pass
                 else:
-                    self.add_line('   :annotation: = ' + objrepr, '<autodoc>')
+                    if objrepr == "None" or self.env.config.matlab_show_property_default_value == False:
+                        objrepr_formatted = ''
+                    else:
+                        objrepr_formatted = f'= {objrepr}'
+
+                    self.add_line('   :annotation: ' + objrepr_formatted, '<autodoc>')
         elif self.options.annotation is SUPPRESS:
             pass
         else:

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -779,6 +779,7 @@ def setup(app):
     app.add_config_value('matlab_src_dir', None, 'env')
     app.add_config_value('matlab_src_encoding', None, 'env')
     app.add_config_value('matlab_keep_package_prefix', True, 'env')
+    app.add_config_value('matlab_show_property_default_value', False, 'env')
 
     app.registry.add_documenter('mat:module', doc.MatModuleDocumenter)
     app.add_directive_to_domain('mat',

--- a/tests/roots/test_autodoc/target/ClassExample.m
+++ b/tests/roots/test_autodoc/target/ClassExample.m
@@ -1,14 +1,16 @@
 classdef ClassExample < handle
     % Example class
     %
-    % :param a: a property of :class:`ClassExample`
+    % :param a: first property of :class:`ClassExample`
+    % :param b: second property of :class:`ClassExample`
 
     properties
         a % a property
+        b = 10 % a property with default value
     end
     methods
         function mc = ClassExample(a)
-            mc.a = a
+            mc.a = a;
         end
 
         function c = mymethod(obj, b)
@@ -17,9 +19,9 @@ classdef ClassExample < handle
         % :param b: an input to :meth:`mymethod`
             for n = 1:10
                 if n > 5
-                    c = obj.a + b
+                    c = obj.a + b;
                 else
-                    c = obj.a + b^2
+                    c = obj.a + b^2;
                 end
             end
         end

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -34,19 +34,28 @@ def test_setup(make_app, rootdir):
 
     assert isinstance(content[3], addnodes.desc)
     assert content[3][0].astext() == 'class target.ClassExample(a)'
-    assert content[3][1].astext() == """Bases: handle
+    assert content[3][1].astext() == \
+"""Bases: handle
 
 Example class
 
 Parameters
 
-a – a property of ClassExample
+a – first property of ClassExample
+
+b – second property of ClassExample
 
 
 
-a = None
+a
 
 a property
+
+
+
+b
+
+a property with default value
 
 
 
@@ -57,9 +66,50 @@ A method in ClassExample
 Parameters
 
 b – an input to mymethod()"""
-    # We still have warning regarding overriding auto...
-    # assert app._warning.getvalue() == ''
 
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_setup_show_default_value(make_app, rootdir):
+    srcdir = rootdir / 'roots' / 'test_autodoc'
+    app = make_app(srcdir=srcdir, confoverrides={'matlab_show_property_default_value': True})
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / 'index.doctree').read_bytes())
+
+    assert isinstance(content[3], addnodes.desc)
+    assert content[3][0].astext() == 'class target.ClassExample(a)'
+    assert content[3][1].astext() == \
+"""Bases: handle
+
+Example class
+
+Parameters
+
+a – first property of ClassExample
+
+b – second property of ClassExample
+
+
+
+a
+
+a property
+
+
+
+b = '10'
+
+a property with default value
+
+
+
+mymethod(b)
+
+A method in ClassExample
+
+Parameters
+
+b – an input to mymethod()"""
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
The new default is now to not show property values.
This is inline with what MathWorks does in their documentation.
Further, if the default value is `None` (i.e not set), it
is not shown anymore.