### PR TITLE
Add test for parse_mlappfile

### DIFF
--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -223,14 +223,14 @@ class MatObject(object):
         :type path: str
         :returns: :class:`MatApplication` representing the application.
         """
-
-        # TODO: We could use this method to parse other matlab binaries
-
         # Read contents of meta-data file
         # This might change in different Matlab versions
+        # Note: `code` is a verbatim copy of the MATLAB source inside the App
+        #       Variable `codeText` will contain the source.
         with ZipFile(mlappfile, "r") as mlapp:
             meta = ET.fromstring(mlapp.read("metadata/appMetadata.xml"))
             core = ET.fromstring(mlapp.read("metadata/coreProperties.xml"))
+            # code = ET.fromstring(mlapp.read("matlab/document.xml"))
 
         metaNs = {"ns": "http://schemas.mathworks.com/appDesigner/app/2017/appMetadata"}
         coreNs = {
@@ -240,9 +240,12 @@ class MatObject(object):
             "dcterms": "http://purl.org/dc/terms/",
             "xsi": "http://www.w3.org/2001/XMLSchema-instance",
         }
+        # codeNs = {"w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main"}
 
         coreDesc = core.find("dc:description", coreNs)
         metaDesc = meta.find("ns:description", metaNs)
+        # codeDesc = code.find(".//w:t", codeNs)
+        # codeText = codeDesc.text
 
         doc = []
         if coreDesc is not None:

--- a/tests/test_parse_mlappfile.py
+++ b/tests/test_parse_mlappfile.py
@@ -1,0 +1,21 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+from sphinxcontrib import mat_types
+import os
+import pytest
+
+
+DIRNAME = os.path.abspath(os.path.dirname(__file__))
+TESTDATA_ROOT = os.path.join(DIRNAME, "test_data")
+TESTDATA_SUB = os.path.join(TESTDATA_ROOT, "submodule")
+
+
+def test_Application():
+    mfile = os.path.join(TESTDATA_ROOT, "Application.mlapp")
+    obj = mat_types.MatObject.parse_mlappfile(mfile, "Application", "test_data")
+    assert obj.name == "Application"
+    assert obj.docstring == "Summary of app\n\nDescription of app"
+
+
+if __name__ == "__main__":
+    pytest.main([os.path.abspath(__file__)])


### PR DESCRIPTION
Add and explicit test of `parse_mlappfile`.
Add examples on how to extract to source code inside the App.