### PR TITLE
Clean up logging messages and linter issue.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+ignore = D203,E203,W503
 exclude = .git,*migrations*,.venv*
 max-line-length = 127
 max-complexity = 10

--- a/sphinxcontrib/mat_directives.py
+++ b/sphinxcontrib/mat_directives.py
@@ -36,10 +36,10 @@ class MatlabAutodocDirective(AutodocDirective):
         except AttributeError:
             source, lineno = (None, None)
         logger.debug(
-            "[sphinxcontrib-matlabdomain] %s:%s: input:\n%s",
+            "[sphinxcontrib-matlabdomain] Input at %s:%s\n\n%s\n",
             source,
             lineno,
-            self.block_text,
+            self.block_text.strip(),
         )
 
         # look up target Documenter
@@ -54,8 +54,9 @@ class MatlabAutodocDirective(AutodocDirective):
         except (KeyError, ValueError, TypeError) as exc:
             # an option is either unknown or has a wrong type
             logger.error(
-                "An option to %s is either unknown or has an invalid value: %s"
-                % (self.name, exc),
+                "[sphinxcontrib-matlabdomain] An option to %s is either unknown or has an invalid value: %s",
+                self.name,
+                exc,
                 location=(source, lineno),
             )
             return []
@@ -69,8 +70,12 @@ class MatlabAutodocDirective(AutodocDirective):
         if not params.result:
             return []
 
+        lines = "\n".join(params.result)
         logger.debug(
-            "[sphinxcontrib-matlabdomain] output:\n%s", "\n".join(params.result)
+            "[sphinxcontrib-matlabdomain] Generated output at %s:%s\n%s",
+            source,
+            lineno,
+            lines,
         )
 
         # record all filenames as dependencies -- this will at least

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -91,7 +91,9 @@ class MatlabDocumenter(PyDocumenter):
             ).groups()
         except AttributeError:
             logger.warning(
-                "invalid signature for auto%s (%r)" % (self.objtype, self.name)
+                "[sphinxcontrib-matlabdomain] Invalid signature for mat:auto%s (%r)",
+                self.objtype,
+                self.name,
             )
             return False
 
@@ -155,11 +157,11 @@ class MatlabDocumenter(PyDocumenter):
         except Exception:
             if self.objpath:
                 errmsg = (
-                    "[sphinxcontrib-matlabdomain]: failed to import %s %r from module %r"
+                    "[sphinxcontrib-matlabdomain] Failed to import %s %r from module %r"
                     % (self.objtype, ".".join(self.objpath), self.modname)
                 )
             else:
-                errmsg = "[sphinxcontrib-matlabdomain]: failed to import %s %r" % (
+                errmsg = "[sphinxcontrib-matlabdomain] Failed to import %s %r" % (
                     self.objtype,
                     self.fullname,
                 )
@@ -233,7 +235,9 @@ class MatlabDocumenter(PyDocumenter):
                 except AttributeError:
                     if mname not in analyzed_member_names:
                         logger.warning(
-                            "missing attribute %s in object %s" % (mname, self.fullname)
+                            "[sphinxcontrib-matlabdomain] missing attribute %s in object %s",
+                            mname,
+                            self.fullname,
                         )
         elif self.options.inherited_members:
             # safe_getmembers() uses dir() which pulls in members from all
@@ -548,9 +552,10 @@ class MatlabDocumenter(PyDocumenter):
         if not self.parse_name():
             # need a module to import
             logger.warning(
-                "don't know which module to import for autodocumenting "
+                "[sphinxcontrib-matlabdomain] don't know which module to import for autodocumenting "
                 '%r (try placing a "module" or "currentmodule" directive '
-                "in the document, or giving an explicit module name)" % self.name
+                "in the document, or giving an explicit module name)",
+                self.name,
             )
             return
 
@@ -615,8 +620,8 @@ class MatModuleDocumenter(MatlabDocumenter, PyModuleDocumenter):
         ret = MatlabDocumenter.parse_name(self)
         if self.args or self.retann:
             logger.warning(
-                "signature arguments or return annotation "
-                "given for automodule %s" % self.fullname
+                "[sphinxcontrib-matlabdomain] signature arguments or return annotation given for automodule %s",
+                self.fullname,
             )
         return ret
 
@@ -651,14 +656,9 @@ class MatModuleDocumenter(MatlabDocumenter, PyModuleDocumenter):
                     raise AttributeError
             except AttributeError:
                 logger.warning(
-                    "missing attribute mentioned in :members: or __all__: "
-                    "module %s, attribute %s"
-                    % (
-                        sphinx.util.inspect.safe_getattr(
-                            self.object, "__name__", "???"
-                        ),
-                        mname,
-                    )
+                    "[sphinxcontrib-matlabdomain] missing attribute mentioned in :members: or __all__: module %s, attribute %s",
+                    sphinx.util.inspect.safe_getattr(self.object, "__name__", "???"),
+                    mname,
                 )
         return False, ret
 

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -9,7 +9,6 @@
     :license: BSD, see LICENSE for details.
 """
 from .mat_types import (
-    MatModule,
     MatObject,
     MatFunction,
     MatClass,
@@ -23,7 +22,6 @@ from .mat_types import (
 )
 
 import re
-import sys
 import traceback
 import inspect
 
@@ -656,7 +654,8 @@ class MatModuleDocumenter(MatlabDocumenter, PyModuleDocumenter):
                     raise AttributeError
             except AttributeError:
                 logger.warning(
-                    "[sphinxcontrib-matlabdomain] missing attribute mentioned in :members: or __all__: module %s, attribute %s",
+                    "[sphinxcontrib-matlabdomain] missing attribute mentioned"
+                    " in :members: or __all__: module %s, attribute %s",
                     sphinx.util.inspect.safe_getattr(self.object, "__name__", "???"),
                     mname,
                 )
@@ -908,7 +907,9 @@ class MatClassDocumenter(MatModuleLevelDocumenter):
                 init_doc.object = self.get_attr(self.object, self.object.name, None)
                 init_doc.objpath = [self.object.name]
                 init_doc._find_signature()  # this effects to get_doc() result
-                initdocstring = "\n".join(["\n".join(l) for l in init_doc.get_doc()])
+                initdocstring = "\n".join(
+                    ["\n".join(line) for line in init_doc.get_doc()]
+                )
             else:
                 initdocstring = self.get_attr(
                     self.get_attr(self.object, self.object.name, None), "__doc__"
@@ -1038,7 +1039,7 @@ class MatAttributeDocumenter(MatClassLevelDocumenter):
                 else:
                     if (
                         objrepr == "None"
-                        or self.env.config.matlab_show_property_default_value == False
+                        or self.env.config.matlab_show_property_default_value is False
                     ):
                         objrepr_formatted = ""
                     else:

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -8,7 +8,8 @@
     :copyright: Copyright 2014 Mark Mikofski
     :license: BSD, see LICENSE for details.
 """
-from .mat_types import (
+from .mat_types import (  # noqa: E401
+    MatModule,
     MatObject,
     MatFunction,
     MatClass,

--- a/sphinxcontrib/mat_lexer.py
+++ b/sphinxcontrib/mat_lexer.py
@@ -15,11 +15,8 @@
     - Removed unused lexers (MatlabSessionLexer, OctaveLexer, ScilabLexer)
 """
 
-import re
-
-from pygments.lexer import Lexer, RegexLexer, bygroups, words, do_insertions
+from pygments.lexer import RegexLexer, bygroups, words
 from pygments.token import (
-    Token,
     Text,
     Comment,
     Operator,
@@ -28,11 +25,8 @@ from pygments.token import (
     String,
     Number,
     Punctuation,
-    Generic,
     Whitespace,
 )
-
-from pygments.lexers import _scilab_builtins
 
 __all__ = ["MatlabLexer"]
 

--- a/sphinxcontrib/mat_lexer.py
+++ b/sphinxcontrib/mat_lexer.py
@@ -16,7 +16,8 @@
 """
 
 from pygments.lexer import RegexLexer, bygroups, words
-from pygments.token import (
+from pygments.token import (  # noqa: F401
+    Token,
     Text,
     Comment,
     Operator,

--- a/sphinxcontrib/mat_parser.py
+++ b/sphinxcontrib/mat_parser.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""
+Functions for parsing MatlabLexer output.
+
+:copyright: Copyright 2023 Jørgen Cederberg
+:license: BSD, see LICENSE for details.
+"""
+
+import re
+import sphinx.util
+
+logger = sphinx.util.logging.getLogger("matlab-domain")
+
+
+def remove_comment_header(code):
+    """
+    Removes the comment header (if there is one) and empty lines from the
+    top of the current read code.
+    :param code: Current code string.
+    :type code: str
+    :returns: Code string without comments above a function, class or
+            procedure/script.
+    """
+    # get the line number when the comment header ends (incl. empty lines)
+    ln_pos = 0
+    for line in code.splitlines(True):
+        if re.match(r"[ \t]*(%|\n)", line):
+            ln_pos += 1
+        else:
+            break
+
+    if ln_pos > 0:
+        # remove the header block and empty lines from the top of the code
+        try:
+            code = code.split("\n", ln_pos)[ln_pos:][0]
+        except IndexError:
+            # only header and empty lines.
+            code = ""
+
+    return code
+
+
+def remove_line_continuations(code):
+    """
+    Removes line continuations (...) from code as functions must be on a
+    single line
+    :param code:
+    :type code: str
+    :return:
+    """
+    pat = r"('.*)(\.\.\.)(.*')"
+    code = re.sub(pat, r"\g<1>\g<3>", code, flags=re.MULTILINE)
+
+    pat = r"^([^%'\"\n]*)(\.\.\..*\n)"
+    code = re.sub(pat, r"\g<1>", code, flags=re.MULTILINE)
+    return code
+
+
+def fix_function_signatures(code):
+    """
+    Transforms function signatures with line continuations to a function
+    on a single line with () appended. Required because pygments cannot
+    handle this situation correctly.
+
+    :param code:
+    :type code: str
+    :return: Code string with functions on single line
+    """
+    pat = r"""^[ \t]*function[ \t.\n]*  # keyword (function)
+                        (\[?[\w, \t.\n]*\]?)      # outputs: group(1)
+                        [ \t.\n]*=[ \t.\n]*       # punctuation (eq)
+                        (\w+)[ \t.\n]*            # name: group(2)
+                        \(?([\w, \t.\n]*)\)?"""  # args: group(3)
+    pat = re.compile(pat, re.X | re.MULTILINE)  # search start of every line
+
+    # replacement function
+    def repl(m):
+        retv = m.group(0)
+        # if no args and doesn't end with parentheses, append "()"
+        if not (m.group(3) or m.group(0).endswith("()")):
+            retv = retv.replace(m.group(2), m.group(2) + "()")
+        return retv
+
+    code = pat.sub(repl, code)  # search for functions and apply replacement
+
+    return code

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -18,12 +18,12 @@ from sphinxcontrib.mat_lexer import MatlabLexer
 from pygments.token import Token
 from zipfile import ZipFile
 import xml.etree.ElementTree as ET
+import sphinxcontrib.mat_parser as mat_parser
 
 logger = sphinx.util.logging.getLogger("matlab-domain")
 
 modules = {}
 
-MAT_DOM = "sphinxcontrib-matlabdomain"
 __all__ = [
     "MatObject",
     "MatModule",
@@ -35,7 +35,6 @@ __all__ = [
     "MatException",
     "MatModuleAnalyzer",
     "MatApplication",
-    "MAT_DOM",
 ]
 
 # TODO: use `self.tokens.pop()` instead of idx += 1, see MatFunction
@@ -88,8 +87,11 @@ class MatObject(object):
         if name == "__name__":
             return self.__name__
         elif len(defargs) == 0:
-            warn_msg = '[%s] WARNING Attribute "%s" was not found in %s.'
-            logger.debug(warn_msg, MAT_DOM, name, self)
+            logger.debug(
+                '[sphinxcontrib-matlabdomain] Warning attribute "%s" was not found in %s.',
+                name,
+                self,
+            )
             return None
         elif len(defargs) == 1:
             return defargs[0]
@@ -131,24 +133,30 @@ class MatObject(object):
         if os.path.isdir(fullpath):
             mod = modules.get(package)
             if mod:
-                msg = "[%s] mod %s already loaded."
-                logger.debug(msg, MAT_DOM, package)
+                logger.debug(
+                    "[sphinxcontrib-matlabdomain] Module %s already loaded.", package
+                )
                 return mod
             else:
-                msg = "[%s] matlabify %s from\n\t%s."
-                logger.debug(msg, MAT_DOM, package, fullpath)
+                logger.debug(
+                    "[sphinxcontrib-matlabdomain] matlabify %s from %s.",
+                    package,
+                    fullpath,
+                )
                 return MatModule(name, fullpath, package)  # import package
         elif os.path.isfile(fullpath + ".m"):
             mfile = fullpath + ".m"
-            msg = "[%s] matlabify %s from\n\t%s."
-            logger.debug(msg, MAT_DOM, package, mfile)
+            logger.debug(
+                "[sphinxcontrib-matlabdomain] matlabify %s from %s.", package, mfile
+            )
             return MatObject.parse_mfile(
                 mfile, name, path, MatObject.encoding
             )  # parse mfile
         elif os.path.isfile(fullpath + ".mlapp"):
             mlappfile = fullpath + ".mlapp"
-            msg = "[%s] matlabify %s from\n\t%s."
-            logger.debug(msg, MAT_DOM, package, mlappfile)
+            logger.debug(
+                "[sphinxcontrib-matlabdomain] matlabify %s from %s.", package, mlappfile
+            )
             return MatObject.parse_mlappfile(mlappfile, name, path)
         return None
 
@@ -181,10 +189,11 @@ class MatObject(object):
             code = code_f.read().replace("\r\n", "\n")
 
         full_code = code
+
         # remove the top comment header (if there is one) from the code string
-        code = MatObject._remove_comment_header(code)
-        code = MatObject._remove_line_continuations(code)
-        code = MatObject._fix_function_signatures(code)
+        code = mat_parser.remove_comment_header(code)
+        code = mat_parser.remove_line_continuations(code)
+        code = mat_parser.fix_function_signatures(code)
 
         tks = list(MatlabLexer().get_tokens(code))
 
@@ -198,10 +207,18 @@ class MatObject(object):
             return token == (Token.Keyword, "classdef")
 
         if isClass(tks[0]):
-            logger.debug("[%s] parsing classdef %s from %s.", MAT_DOM, name, modname)
+            logger.debug(
+                "[sphinxcontrib-matlabdomain] parsing classdef %s from %s.",
+                name,
+                modname,
+            )
             return MatClass(name, modname, tks)
         elif isFunction(tks[0]):
-            logger.debug("[%s] parsing function %s from %s.", MAT_DOM, name, modname)
+            logger.debug(
+                "[sphinxcontrib-matlabdomain] parsing function %s from %s.",
+                name,
+                modname,
+            )
             return MatFunction(name, modname, tks)
         else:
             # it's a script file retoken with header comment
@@ -258,81 +275,6 @@ class MatObject(object):
         modname = path.replace(os.sep, ".")  # module name
 
         return MatApplication(name, modname, docstring)
-
-    @staticmethod
-    def _remove_comment_header(code):
-        """
-        Removes the comment header (if there is one) and empty lines from the
-        top of the current read code.
-        :param code: Current code string.
-        :type code: str
-        :returns: Code string without comments above a function, class or
-                  procedure/script.
-        """
-        # get the line number when the comment header ends (incl. empty lines)
-        ln_pos = 0
-        for line in code.splitlines(True):
-            if re.match(r"[ \t]*(%|\n)", line):
-                ln_pos += 1
-            else:
-                break
-
-        if ln_pos > 0:
-            # remove the header block and empty lines from the top of the code
-            try:
-                code = code.split("\n", ln_pos)[ln_pos:][0]
-            except IndexError:
-                # only header and empty lines.
-                code = ""
-
-        return code
-
-    @staticmethod
-    def _remove_line_continuations(code):
-        """
-        Removes line continuations (...) from code as functions must be on a
-        single line
-        :param code:
-        :type code: str
-        :return:
-        """
-        pat = r"('.*)(\.\.\.)(.*')"
-        code = re.sub(pat, r"\g<1>\g<3>", code, flags=re.MULTILINE)
-
-        pat = r"^([^%'\"\n]*)(\.\.\..*\n)"
-        code = re.sub(pat, r"\g<1>", code, flags=re.MULTILINE)
-        return code
-
-    @staticmethod
-    def _fix_function_signatures(code):
-        """
-        Transforms function signatures with line continuations to a function
-        on a single line with () appended. Required because pygments cannot
-        handle this situation correctly.
-
-        :param code:
-        :type code: str
-        :return: Code string with functions on single line
-        """
-        pat = r"""^[ \t]*function[ \t.\n]*  # keyword (function)
-                              (\[?[\w, \t.\n]*\]?)      # outputs: group(1)
-                              [ \t.\n]*=[ \t.\n]*       # punctuation (eq)
-                              (\w+)[ \t.\n]*            # name: group(2)
-                              \(?([\w, \t.\n]*)\)?"""  # args: group(3)
-        pat = re.compile(pat, re.X | re.MULTILINE)  # search start of every line
-
-        # replacement function
-        def repl(m):
-            retv = m.group(0)
-            # if no args and doesn't end with parentheses, append "()"
-            if not (m.group(3) or m.group(0).endswith("()")):
-                retv = retv.replace(m.group(2), m.group(2) + "()")
-            return retv
-
-        code = pat.sub(repl, code)  # search for functions and apply replacement
-        msg = "[%s] replaced ellipsis & appended parentheses in function signatures"
-        logger.debug(msg, MAT_DOM)
-        return code
 
 
 # TODO: get docstring and __all__ from contents.m if exists
@@ -420,19 +362,27 @@ class MatModule(MatObject):
         elif name == "__package__":
             return self.__package__
         elif name == "__module__":
-            msg = "[%s] mod %s is a package does not have __module__."
-            logger.debug(msg, MAT_DOM, self)
+            logger.debug(
+                "[sphinxcontrib-matlabdomain] mod %s is a package does not have __module__.",
+                self,
+            )
             return None
         else:
             if hasattr(self, name):
-                msg = "[%s] mod %s already has attr %s."
-                logger.debug(msg, MAT_DOM, self, name)
+                logger.debug(
+                    "[sphinxcontrib-matlabdomain] mod %s already has attr %s.",
+                    self,
+                    name,
+                )
                 return getattr(self, name)
             attr = MatObject.matlabify(".".join([self.package, name]))
             if attr:
                 setattr(self, name, attr)
-                msg = "[%s] attr %s imported from mod %s."
-                logger.debug(msg, MAT_DOM, name, self)
+                logger.debug(
+                    "[sphinxcontrib-matlabdomain] attr %s imported from mod %s.",
+                    name,
+                    self,
+                )
                 return attr
             else:
                 super(MatModule, self).getter(name, *defargs)
@@ -637,10 +587,11 @@ class MatFunction(MatObject):
                         ]
                 if tks.pop() != (Token.Punctuation, "="):
                     # Unlikely to end here. But never-the-less warn!
-                    msg = '[sphinxcontrib-matlabdomain] Parsing failed in {}.{}. Expected "=".'.format(
-                        modname, name
+                    logger.warning(
+                        "[sphinxcontrib-matlabdomain] Parsing failed in %s.%s. Expected '='.",
+                        modname,
+                        name,
                     )
-                    logger.warning(msg)
                     return
 
                 skip_whitespace(tks)
@@ -657,12 +608,13 @@ class MatFunction(MatObject):
                 if isinstance(self, MatMethod):
                     self.name = func_name[1]
                 else:
-                    msg = (
-                        '[sphinxcontrib-matlabdomain] Unexpected function name: "%s".'
-                        % func_name[1]
+                    logger.warning(
+                        "[sphinxcontrib-matlabdomain] Unexpected function name: '%s'. "
+                        "Expected '%s' in module '%s'.",
+                        func_name[1],
+                        name,
+                        modname,
                     )
-                    msg += ' Expected "{}" in module "{}".'.format(name, modname)
-                    logger.warning(msg)
 
             # =====================================================================
             # input args
@@ -678,10 +630,11 @@ class MatFunction(MatObject):
                 # check if function args parsed correctly
                 if tks.pop() != (Token.Punctuation, ")"):
                     # Unlikely to end here. But never-the-less warn!
-                    msg = '[sphinxcontrib-matlabdomain] Parsing failed in {}.{}. Expected ")".'.format(
-                        modname, name
+                    logger.warning(
+                        "[sphinxcontrib-matlabdomain] Parsing failed in {}.{}. Expected ')'.",
+                        modname,
+                        name,
                     )
-                    logger.warning(msg)
                     return
 
             skip_whitespace(tks)
@@ -740,10 +693,11 @@ class MatFunction(MatObject):
                     break
             tks.append(kw)  # put last token back in list
         except IndexError:
-            msg = "[sphinxcontrib-matlabdomain] Parsing failed in {}.{}. Check if valid MATLAB code.".format(
-                modname, name
+            logger.warning(
+                "[sphinxcontrib-matlabdomain] Parsing failed in %s.%s. Check if valid MATLAB code.",
+                modname,
+                name,
             )
-            logger.warning(msg)
         # if there are any tokens left save them
         if len(tks) > 0:
             self.rem_tks = tks  # save extra tokens
@@ -855,12 +809,14 @@ class MatClass(MatMixin, MatObject):
             # classname
             idx += self._blanks(idx)  # skip blanks
             if self._tk_ne(idx, (Token.Name, self.name)):
-                msg = (
-                    '[sphinxcontrib-matlabdomain] Unexpected class name: "%s".'
-                    % self.tokens[idx][1]
+                logger.warning(
+                    "[sphinxcontrib-matlabdomain] Unexpected class name: '%s'."
+                    " Expected '%s' in '%s'.",
+                    self.tokens[idx][1],
+                    name,
+                    modname,
                 )
-                msg += ' Expected "{0}" in "{1}.{0}".'.format(name, modname)
-                logger.warning(msg)
+
             idx += 1
             idx += self._blanks(idx)  # skip blanks
             # =====================================================================
@@ -989,11 +945,11 @@ class MatClass(MatMixin, MatObject):
                         # subtype of Name EG Name.Builtin used as Name
                         elif self.tokens[idx][0] in Token.Name.subtypes:
                             prop_name = self.tokens[idx][1]
-                            warn_msg = " ".join(
-                                ["[%s] WARNING %s.%s.%s is", "a Builtin Name"]
-                            )
                             logger.debug(
-                                warn_msg, MAT_DOM, self.module, self.name, prop_name
+                                "[sphinxcontrib-matlabdomain] WARNING %s.%s.%s is a builtin name.",
+                                self.module,
+                                self.name,
+                                prop_name,
                             )
                             self.properties[prop_name] = {"attrs": attr_dict}
                             idx += 1
@@ -1028,9 +984,11 @@ class MatClass(MatMixin, MatObject):
                                 self.properties[prop_name]["docstring"] = docstring
                                 idx += 1
                         else:
-                            msg = "[sphinxcontrib-matlabdomain] Expected property in %s.%s - got %s"
                             logger.warning(
-                                msg, self.module, self.name, str(self.tokens[idx])
+                                "sphinxcontrib-matlabdomain] Expected property in %s.%s - got %s",
+                                self.module,
+                                self.name,
+                                str(self.tokens[idx]),
                             )
                             return
                         idx += self._blanks(idx)  # skip blanks
@@ -1139,8 +1097,12 @@ class MatClass(MatMixin, MatObject):
                             or self._tk_eq(idx, (Token.Punctuation, ";"))
                             or self._tk_eq(idx, (Token.Punctuation, ","))
                         ):
-                            msg = "[%s] Skipping tokens for methods defined in separate files.\ntoken #%d: %r"
-                            logger.debug(msg, MAT_DOM, idx, self.tokens[idx])
+                            logger.debug(
+                                "[sphinxcontrib-matlabdomain] Skipping tokens for methods defined in separate files."
+                                "Token #%d: %r",
+                                idx,
+                                self.tokens[idx],
+                            )
                             idx += 1 + self._whitespace(idx + 1)
                         elif self._tk_eq(idx, (Token.Keyword, "end")):
                             idx += 1
@@ -1163,26 +1125,32 @@ class MatClass(MatMixin, MatObject):
                             idx += self._whitespace(idx)
                     idx += 1
                 if self._tk_eq(idx, (Token.Keyword, "events")):
-                    msg = "[%s] ignoring " "events" " in " "classdef %s." ""
-                    logger.debug(msg, MAT_DOM, self.name)
+                    logger.debug(
+                        "[sphinxcontrib-matlabdomain] ignoring 'events' in 'classdef %s.'",
+                        self.name,
+                    )
                     idx += 1
                     # Token.Keyword: "end" terminates events block
                     while self._tk_ne(idx, (Token.Keyword, "end")):
                         idx += 1
                     idx += 1
                 if self._tk_eq(idx, (Token.Name, "enumeration")):
-                    msg = "[%s] ignoring " "enumeration" " in " "classdef %s." ""
-                    logger.debug(msg, MAT_DOM, self.name)
+                    logger.debug(
+                        "[sphinxcontrib-matlabdomain] ignoring 'enumeration' in 'classdef %s'.",
+                        self.name,
+                    )
                     idx += 1
                     # Token.Keyword: "end" terminates events block
                     while self._tk_ne(idx, (Token.Keyword, "end")):
                         idx += 1
                     idx += 1
         except IndexError:
-            msg = "[sphinxcontrib-matlabdomain] Parsing failed in {}.{}. Check if valid MATLAB code.".format(
-                modname, name
+            logger.warning(
+                "[sphinxcontrib-matlabdomain] Parsing failed in %s.%s. "
+                "Check if valid MATLAB code.",
+                modname,
+                name,
             )
-            logger.warning(msg)
 
         self.rem_tks = idx  # index of last token
 
@@ -1204,12 +1172,13 @@ class MatClass(MatMixin, MatObject):
                     attr_dict[attr_name] = True  # add attibute to dictionary
                     idx += 1
                 elif k is Token.Name:
-                    msg = (
-                        '[sphinxcontrib-matlabdomain] Unexpected class attribute: "%s".'
-                        % str(self.tokens[idx][1])
+                    logger.warning(
+                        "[sphinxcontrib-matlabdomain] Unexpected class attribute: '%s'. "
+                        " In '%s.%s'.",
+                        str(self.tokens[idx][1]),
+                        self.module,
+                        self.name,
                     )
-                    msg += ' In "{0}.{1}".'.format(self.module, self.name)
-                    logger.warning(msg)
                     idx += 1
 
                 idx += self._blanks(idx)  # skip blanks

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -10,8 +10,6 @@
 """
 from io import open  # for opening files with encoding in Python 2
 import os
-import re
-import sys
 from copy import copy
 import sphinx.util
 from sphinxcontrib.mat_lexer import MatlabLexer
@@ -932,7 +930,7 @@ class MatClass(MatMixin, MatObject):
                             prop_name = self.tokens[idx][1]
                             idx += 1
                             # Initialize property if it was not already done
-                            if not prop_name in self.properties.keys():
+                            if prop_name not in self.properties.keys():
                                 self.properties[prop_name] = {"attrs": attr_dict}
 
                             # skip size, class and functions specifiers

--- a/tests/test_duplicated_link.py
+++ b/tests/test_duplicated_link.py
@@ -38,7 +38,9 @@ def test_with_prefix(make_app, rootdir):
     section = content[0][7]
     assert (
         section.astext()
-        == "NiceFiniteGroup\n\n\n\nclass +replab.NiceFiniteGroup\n\nBases: +replab.FiniteGroup\n\nA nice finite group is a finite group equipped with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv"
+        == "NiceFiniteGroup\n\n\n\nclass +replab.NiceFiniteGroup\n\nBases: "
+        "+replab.FiniteGroup\n\nA nice finite group is a finite group equipped "
+        "with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv"
     )
 
 

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -249,7 +249,8 @@ def test_folder_class(mod):
     assert func.retv == ["varargout"]
     assert (
         func.docstring
-        == " CLASSMETHOD A function within a package\n\n :param obj: An instance of this class.\n :param varargin: Variable input arguments.\n :returns: varargout\n"
+        == " CLASSMETHOD A function within a package\n\n :param obj: An instance of this class.\n"
+        " :param varargin: Variable input arguments.\n :returns: varargout\n"
     )
 
 

--- a/tests/test_package_links.py
+++ b/tests/test_package_links.py
@@ -41,7 +41,8 @@ def test_with_prefix(make_app, rootdir):
     assert isinstance(content[5], addnodes.desc)
     assert (
         content[5].astext()
-        == "class +replab.Action\n\nBases: +replab.Str\n\nAn action group …\n\n\n\nleftAction(self, g, p)\n\nReturns the left action"
+        == "class +replab.Action\n\nBases: +replab.Str\n\nAn action group"
+        " …\n\n\n\nleftAction(self, g, p)\n\nReturns the left action"
     )
 
 

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -456,7 +456,8 @@ def test_f_with_name_mismatch(caplog):
         (
             "sphinx.matlab-domain",
             WARNING,
-            '[sphinxcontrib-matlabdomain] Unexpected function name: "f_name_with_mismatch". Expected "f_with_name_mismatch" in module "test_data".',
+            '[sphinxcontrib-matlabdomain] Unexpected function name: "f_name_with_mismatch".'
+            ' Expected "f_with_name_mismatch" in module "test_data".',
         ),
     ]
 
@@ -534,7 +535,8 @@ def test_ClassWithNameMismatch(caplog):
         (
             "sphinx.matlab-domain",
             WARNING,
-            '[sphinxcontrib-matlabdomain] Unexpected class name: "ClassWithMismatch". Expected "ClassWithNameMismatch" in "test_data.ClassWithNameMismatch".',
+            '[sphinxcontrib-matlabdomain] Unexpected class name: "ClassWithMismatch". '
+            'Expected "ClassWithNameMismatch" in "test_data.ClassWithNameMismatch".',
         ),
     ]
 
@@ -713,7 +715,7 @@ def test_ClassWithLongPropertyDocstrings():
     assert obj.properties["b"]["docstring"] == " Document this property\n"
 
 
-def test_ClassWithLongPropertyDocstrings():
+def test_ClassWithLongPropertyTrailingEmptyDocstrings():
     mfile = os.path.join(
         TESTDATA_ROOT, "ClassWithLongPropertyTrailingEmptyDocstrings.m"
     )


### PR DESCRIPTION
* All messages are prefixed with `[sphinxcontrib-matlabdomain]`.
* Use logger argument instead of build `msg` strings before.
* Started extraction of parser functionality `mat_parser.py`.
* Fixed various linter issues.