### PR TITLE
display class members in separate lists w/headings

### DIFF
--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -947,32 +947,38 @@ class MatClassDocumenter(MatModuleLevelDocumenter):
         # find out which members are documentable
         members_check_module, members = self.get_object_members(want_all)
 
+        # use filtered members to check for empty sections
+        filtered_members = [
+            (membername, member)
+            for (membername, member, isattr) in self.filter_members(members, want_all)
+        ]
+
         # create list of properties
         prop_names = [
             membername
-            for (membername, member) in members
+            for (membername, member) in filtered_members
             if isinstance(member, MatProperty)
         ]
         # create list of constructors
-        if self.env.config.autoclass_content == "init":
+        if self.env.config.autoclass_content in ("both", "init"):
             # skip constructor section, since its docstring has already been used for the class
             cons_names = []
         else:
             cons_names = [
                 membername
-                for (membername, member) in members
+                for (membername, member) in filtered_members
                 if isinstance(member, MatMethod) and member.name == member.cls.name
             ]
         # create list of non-constructor methods
         meth_names = [
             membername
-            for (membername, member) in members
+            for (membername, member) in filtered_members
             if isinstance(member, MatMethod) and member.name != member.cls.name
         ]
         # create list of other members
         other_names = [
             membername
-            for (membername, member) in members
+            for (membername, member) in filtered_members
             if not isinstance(member, MatMethod) and not isinstance(member, MatProperty)
         ]
         # create list of members that are not properties

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -48,10 +48,6 @@ b – second property of ClassExample
 
 c – third property of ClassExample
 
-Constructor Summary
-
-
-
 Property Summary
 
 
@@ -115,10 +111,6 @@ a – first property of ClassExample
 b – second property of ClassExample
 
 c – third property of ClassExample
-
-Constructor Summary
-
-
 
 Property Summary
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -48,6 +48,14 @@ b – second property of ClassExample
 
 c – third property of ClassExample
 
+Constructor Summary
+
+
+
+Property Summary
+
+
+
 
 
 a
@@ -65,6 +73,10 @@ a property with default value
 c
 
 a property with multiline default value
+
+Method Summary
+
+
 
 
 
@@ -104,6 +116,14 @@ b – second property of ClassExample
 
 c – third property of ClassExample
 
+Constructor Summary
+
+
+
+Property Summary
+
+
+
 
 
 a
@@ -121,6 +141,10 @@ a property with default value
 c = [10; ... 30]
 
 a property with multiline default value
+
+Method Summary
+
+
 
 
 

--- a/tests/test_duplicated_link.py
+++ b/tests/test_duplicated_link.py
@@ -40,7 +40,7 @@ def test_with_prefix(make_app, rootdir):
         section.astext()
         == "NiceFiniteGroup\n\n\n\nclass +replab.NiceFiniteGroup\n\nBases: "
         "+replab.FiniteGroup\n\nA nice finite group is a finite group equipped "
-        "with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv"
+        "with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv\n\nMethod Summary\n\n"
     )
 
 
@@ -57,7 +57,7 @@ def test_without_prefix(make_app, rootdir):
     section = content[0][7]
     assert (
         section.astext()
-        == "NiceFiniteGroup\n\n\n\nclass replab.NiceFiniteGroup\n\nBases: replab.FiniteGroup\n\nA nice finite group is a finite group equipped with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv"
+        == "NiceFiniteGroup\n\n\n\nclass replab.NiceFiniteGroup\n\nBases: replab.FiniteGroup\n\nA nice finite group is a finite group equipped with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv\n\nMethod Summary\n\n"
     )
 
 

--- a/tests/test_duplicated_link.py
+++ b/tests/test_duplicated_link.py
@@ -40,7 +40,7 @@ def test_with_prefix(make_app, rootdir):
         section.astext()
         == "NiceFiniteGroup\n\n\n\nclass +replab.NiceFiniteGroup\n\nBases: "
         "+replab.FiniteGroup\n\nA nice finite group is a finite group equipped "
-        "with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv\n\nMethod Summary\n\n"
+        "with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv"
     )
 
 
@@ -57,7 +57,7 @@ def test_without_prefix(make_app, rootdir):
     section = content[0][7]
     assert (
         section.astext()
-        == "NiceFiniteGroup\n\n\n\nclass replab.NiceFiniteGroup\n\nBases: replab.FiniteGroup\n\nA nice finite group is a finite group equipped with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv\n\nMethod Summary\n\n"
+        == "NiceFiniteGroup\n\n\n\nclass replab.NiceFiniteGroup\n\nBases: replab.FiniteGroup\n\nA nice finite group is a finite group equipped with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv"
     )
 
 

--- a/tests/test_package_links.py
+++ b/tests/test_package_links.py
@@ -36,13 +36,13 @@ def test_with_prefix(make_app, rootdir):
     assert isinstance(content[3], addnodes.desc)
     assert (
         content[3].astext()
-        == "class +replab.Str\n\nBases: handle\n\nDefines a ‘str’ default method and overloads ‘disp’"
+        == "class +replab.Str\n\nBases: handle\n\nDefines a ‘str’ default method and overloads ‘disp’\n\nMethod Summary\n\n"
     )
     assert isinstance(content[5], addnodes.desc)
     assert (
         content[5].astext()
         == "class +replab.Action\n\nBases: +replab.Str\n\nAn action group"
-        " …\n\n\n\nleftAction(self, g, p)\n\nReturns the left action"
+        " …\n\nMethod Summary\n\n\n\n\n\nleftAction(self, g, p)\n\nReturns the left action"
     )
 
 
@@ -58,12 +58,12 @@ def test_without_prefix(make_app, rootdir):
     assert isinstance(content[3], addnodes.desc)
     assert (
         content[3].astext()
-        == "class replab.Str\n\nBases: handle\n\nDefines a ‘str’ default method and overloads ‘disp’"
+        == "class replab.Str\n\nBases: handle\n\nDefines a ‘str’ default method and overloads ‘disp’\n\nMethod Summary\n\n"
     )
     assert isinstance(content[5], addnodes.desc)
     assert (
         content[5].astext()
-        == "class replab.Action\n\nBases: replab.Str\n\nAn action group …\n\n\n\nleftAction(self, g, p)\n\nReturns the left action"
+        == "class replab.Action\n\nBases: replab.Str\n\nAn action group …\n\nMethod Summary\n\n\n\n\n\nleftAction(self, g, p)\n\nReturns the left action"
     )
 
 

--- a/tests/test_package_links.py
+++ b/tests/test_package_links.py
@@ -36,7 +36,7 @@ def test_with_prefix(make_app, rootdir):
     assert isinstance(content[3], addnodes.desc)
     assert (
         content[3].astext()
-        == "class +replab.Str\n\nBases: handle\n\nDefines a ‘str’ default method and overloads ‘disp’\n\nMethod Summary\n\n"
+        == "class +replab.Str\n\nBases: handle\n\nDefines a ‘str’ default method and overloads ‘disp’"
     )
     assert isinstance(content[5], addnodes.desc)
     assert (
@@ -58,7 +58,7 @@ def test_without_prefix(make_app, rootdir):
     assert isinstance(content[3], addnodes.desc)
     assert (
         content[3].astext()
-        == "class replab.Str\n\nBases: handle\n\nDefines a ‘str’ default method and overloads ‘disp’\n\nMethod Summary\n\n"
+        == "class replab.Str\n\nBases: handle\n\nDefines a ‘str’ default method and overloads ‘disp’"
     )
     assert isinstance(content[5], addnodes.desc)
     assert (


### PR DESCRIPTION
Here is one approach to addressing #179.

As I looked at the code in `MatClassDocumenter.document_members()`, it occurred to me that one could still take advantage of the superclass method by "borrowing" the `exclude_members` option and calling the superclass `document_members()` multiple times with different subsets excluded.

I know this is a bit of a hack, but it does generate roughly the result I'm looking for.

What do you think of this approach?

![Screenshot 2023-04-18 at 3 10 23 PM](https://user-images.githubusercontent.com/11841545/232893787-26c5113e-3159-427f-9bcf-7e1b1625401e.png)
