### PR TITLE
Add option `matlab_auto_link`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,9 +99,9 @@ If you want the closest to MATLAB documentation style, use ``matlab_short_links
 
 ``matlab_auto_link``
    Automatically convert the names of known classes and functions to links using
-   the ``:class:`` and ``:func:`` roles, respectively. Valid values are ``"see_also"``
+   the ``:class:`` and ``:func:`` roles, respectively. Valid values are ``"basic"``
    and ``"all"``.
-   * ``"see_also"`` - applies only to docstring lines that begin with "See also",
+   * ``"basic"`` - applies only to docstring lines that begin with "See also",
      and any subsequent lines before the next blank line.
 
    * ``"all"`` - applies to all docstring lines.

--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,11 @@ Additional Configuration
 If you want the closest to MATLAB documentation style, use ``matlab_short_links
 = True`` in your ``conf.py`` file.
 
+``matlab_auto_link``
+   Automatically link class and function names in docstring lines that begin
+   with "See also" (and any subsequent lines before a blank line).
+   Default is ``False``. *Added in Version 0.20.0*.
+
 
 Roles and Directives
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -98,13 +98,18 @@ If you want the closest to MATLAB documentation style, use ``matlab_short_links
 = True`` in your ``conf.py`` file.
 
 ``matlab_auto_link``
-   Automatically convert the names of known classes and functions to links using
-   the ``:class:`` and ``:func:`` roles, respectively. Valid values are ``"basic"``
+   Automatically convert the names of known entities (e.g. classes, functions,
+   properties, methods) to links Valid values are ``"basic"``
    and ``"all"``.
-   * ``"basic"`` - applies only to docstring lines that begin with "See also",
-     and any subsequent lines before the next blank line.
+   * ``"basic"`` - Auto-links (1) known classes or functions that appear
+     in docstring lines that begin with "See also" and any subsequent
+     lines before the next blank line (unknown names are wrapped in
+     double-backquotes), and (2) property and method names that appear in
+     lists under "<MyClass> Properties:" and "<MyClass> Methods:" headings
+     in class docstrings.
 
-   * ``"all"`` - applies to all docstring lines.
+   * ``"all"`` - Auto-links everything included with ``"basic"``, plus all
+     known classes and functions everywhere else they appear in any docstring.
 
    Default is ``None``. *Added in Version 0.20.0*.
 

--- a/README.rst
+++ b/README.rst
@@ -98,9 +98,15 @@ If you want the closest to MATLAB documentation style, use ``matlab_short_links
 = True`` in your ``conf.py`` file.
 
 ``matlab_auto_link``
-   Automatically link class and function names in docstring lines that begin
-   with "See also" (and any subsequent lines before a blank line).
-   Default is ``False``. *Added in Version 0.20.0*.
+   Automatically convert the names of known classes and functions to links using
+   the ``:class:`` and ``:func:`` roles, respectively. Valid values are ``"see_also"``
+   and ``"all"``.
+   * ``"see_also"`` - applies only to docstring lines that begin with "See also",
+     and any subsequent lines before the next blank line.
+
+   * ``"all"`` - applies to all docstring lines.
+
+   Default is ``None``. *Added in Version 0.20.0*.
 
 
 Roles and Directives

--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,9 @@ If you want the closest to MATLAB documentation style, use ``matlab_short_links
      in class docstrings.
 
    * ``"all"`` - Auto-links everything included with ``"basic"``, plus all
-     known classes and functions everywhere else they appear in any docstring.
+     known classes and functions everywhere else they appear in any docstring,
+     and any names ending with "()" within class, property, or method docstrings
+     that match a method of the corresponding class.
 
    Default is ``None``. *Added in Version 0.20.0*.
 

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -213,6 +213,9 @@ class MatlabDocumenter(PyDocumenter):
                     nn = n.replace("+", "")  # remove + from name
                     pat = nn.replace(".", "\.")  # escape . in pattern
                     pat = "(?<!`)" + pat  # add negative look-behind for `
+                    pat = (
+                        pat + "(?!\s(Properties|Methods):)"
+                    )  # add negative look-ahead for " Properties:" or " Methods:"
                     p = re.compile(pat)
                     # print(f"auto_link: {self.fullname} : {self.objtype} - {nn} {role}")
                     for i in range(len(docstrings)):

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -20,6 +20,7 @@ from .mat_types import (  # noqa: E401
     MatModuleAnalyzer,
     MatApplication,
     entities_table,
+    entities_name_map,
     strip_package_prefix,
 )
 
@@ -197,7 +198,6 @@ class MatlabDocumenter(PyDocumenter):
                         elif match := see_also_re.search(line):
                             is_see_also_line = True  # line begins with "See also"
                             entries_str = match.group(2)  # the entries
-                            entities_name_map = create_entities_name_map(entities_table)
                     elif is_see_also_line:  # blank line following see also section
                         is_see_also_line = False  # end see also section
 
@@ -835,13 +835,6 @@ class MatFunctionDocumenter(MatDocstringSignatureMixin, MatModuleLevelDocumenter
 
     def document_members(self, all_members=False):
         pass
-
-
-def create_entities_name_map(entities_table):
-    entities_name_map = {}
-    for n, o in entities_table.items():
-        entities_name_map[strip_package_prefix(n)] = n
-    return entities_name_map
 
 
 def make_baseclass_links(env, obj):

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -184,7 +184,7 @@ class MatlabDocumenter(PyDocumenter):
     def auto_link(self, docstrings):
         # autolink known names in See also
         if self.env.config.matlab_auto_link == "see_also":
-            see_also_re = re.compile("See also\s+(.+)")
+            see_also_re = re.compile(r"See also:?", re.IGNORECASE)
             see_also_line = False
             for i in range(len(docstrings)):
                 for j in range(len(docstrings[i])):

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -201,7 +201,7 @@ class MatlabDocumenter(PyDocumenter):
                             if role in ["class", "func"]:
                                 nn = n.replace("+", "")  # remove + from name
                                 # escape . and add negative look-behind for `
-                                pat = "(?<!`)" + nn.replace(".", "\.")
+                                pat = r"(?<!`)\b" + nn.replace(".", "\.") + r"\b"
                                 line = re.sub(pat, f":{role}:`{nn}`", line)
                         docstrings[i][j] = line
 
@@ -212,9 +212,9 @@ class MatlabDocumenter(PyDocumenter):
                 if role in ["class", "func"]:
                     nn = n.replace("+", "")  # remove + from name
                     pat = nn.replace(".", "\.")  # escape . in pattern
-                    pat = "(?<!`)" + pat  # add negative look-behind for `
+                    pat = r"(?<!`)\b" + pat  # add negative look-behind for `
                     pat = (
-                        pat + "(?!\s(Properties|Methods):)"
+                        pat + r"\b(?!\s(Properties|Methods):)"
                     )  # add negative look-ahead for " Properties:" or " Methods:"
                     p = re.compile(pat)
                     # print(f"auto_link: {self.fullname} : {self.objtype} - {nn} {role}")

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -241,7 +241,7 @@ class MatlabDocumenter(PyDocumenter):
             if role in ["class", "func"]:
                 nn = n.replace("+", "")  # remove + from name
                 pat = (
-                    r"(?<!(`|\.|\+))\b"  # negative look-behind for ` or . or +
+                    r"(?<!(`|\.|\+|<))\b"  # negative look-behind for ` or . or + or <
                     + nn.replace(".", "\.")  # escape .
                     + r"\b(?!(`|\sProperties|\sMethods):)"  # negative look-ahead for ` or " Properties:" or " Methods:"
                 )

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -251,7 +251,7 @@ class MatlabDocumenter(PyDocumenter):
     def auto_link(self, docstrings):
         # autolink known names in See also
         if (
-            self.env.config.matlab_auto_link == "see_also"
+            self.env.config.matlab_auto_link == "basic"
             or self.env.config.matlab_auto_link == "all"
         ):
             docstrings = self.auto_link_see_also(docstrings)

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -859,21 +859,7 @@ def make_baseclass_links(env, obj):
             if not entity:
                 links.append(":class:`%s`" % base_class_name)
             else:
-                modname = entity.__module__
-                classname = entity.name
-                if not env.config.matlab_keep_package_prefix:
-                    modname = strip_package_prefix(modname)
-
-                if env.config.matlab_short_links:
-                    # modname is only used for package names
-                    # - "target.+package" => "package"
-                    # - "target" => ""
-                    parts = modname.split(".")
-                    parts = [part for part in parts if part.startswith("+")]
-                    modname = ".".join(parts)
-
-                link_name = f"{modname}.{classname}"
-                links.append(f":class:`{base_class_name}<{link_name}>`")
+                links.append(entity.link(env, base_class_name))
 
     return links
 

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -235,7 +235,7 @@ class MatlabDocumenter(PyDocumenter):
         return docstrings
 
     def auto_link_all(self, docstrings):
-        # auto-link everywhere
+        # auto-link known classes and functions everywhere
         for n, o in entities_table.items():
             role = o.ref_role()
             if role in ["class", "func"]:
@@ -1029,11 +1029,17 @@ class MatClassDocumenter(MatModuleLevelDocumenter):
         return docstrings
 
     def link_member(self, type, line):
+        if type == "meth":
+            parens = "()"
+        else:
+            parens = ""
         p = re.compile(r"((\*\s*)?(\b\w*\b))(?=\s*-)")
         if match := p.search(line):
             name = match.group(3)
             line = p.sub(
-                f"* :{type}:`{name} <{self.object.fullname(self.env)}.{name}>`", line, 1
+                f"* :{type}:`{name}{parens} <{self.object.fullname(self.env)}.{name}>`",
+                line,
+                1,
             )
         return line
 

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -873,7 +873,7 @@ def make_baseclass_links(env, obj):
             if not entity:
                 links.append(":class:`%s`" % base_class_name)
             else:
-                links.append(entity.link(env, base_class_name))
+                links.append(entity.link(env))
 
     return links
 

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -171,7 +171,8 @@ class MatlabDocumenter(PyDocumenter):
                 # autodoc-process-docstring is fired and can add some
                 # content if desired
                 docstrings.append([])
-            docstrings = self.auto_link(docstrings)
+            if self.env.config.matlab_auto_link:
+                docstrings = self.auto_link(docstrings)
             for i, line in enumerate(self.process_doc(docstrings)):
                 self.add_line(line, sourcename, i)
 

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -200,8 +200,11 @@ class MatlabDocumenter(PyDocumenter):
                             role = o.ref_role()
                             if role in ["class", "func"]:
                                 nn = n.replace("+", "")  # remove + from name
-                                # escape . and add negative look-behind for `
-                                pat = r"(?<!`)\b" + nn.replace(".", "\.") + r"\b"
+                                pat = (
+                                    r"(?<!(`|\.|\+))\b"  # negative look-behind for ` or . or +
+                                    + nn.replace(".", "\.")  # escape .
+                                    + r"\b(?!`)"  # negative look-ahead for `
+                                )
                                 line = re.sub(pat, f":{role}:`{nn}`", line)
                         docstrings[i][j] = line
 
@@ -211,13 +214,12 @@ class MatlabDocumenter(PyDocumenter):
                 role = o.ref_role()
                 if role in ["class", "func"]:
                     nn = n.replace("+", "")  # remove + from name
-                    pat = nn.replace(".", "\.")  # escape . in pattern
-                    pat = r"(?<!`)\b" + pat  # add negative look-behind for `
                     pat = (
-                        pat + r"\b(?!\s(Properties|Methods):)"
-                    )  # add negative look-ahead for " Properties:" or " Methods:"
+                        r"(?<!(`|\.|\+))\b"  # negative look-behind for ` or . or +
+                        + nn.replace(".", "\.")  # escape .
+                        + r"\b(?!(`|\sProperties|\sMethods):)"  # negative look-ahead for ` or " Properties:" or " Methods:"
+                    )
                     p = re.compile(pat)
-                    # print(f"auto_link: {self.fullname} : {self.objtype} - {nn} {role}")
                     for i in range(len(docstrings)):
                         for j in range(len(docstrings[i])):
                             docstrings[i][j] = p.sub(

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -184,7 +184,10 @@ class MatlabDocumenter(PyDocumenter):
 
     def auto_link(self, docstrings):
         # autolink known names in See also
-        if self.env.config.matlab_auto_link == "see_also":
+        if (
+            self.env.config.matlab_auto_link == "see_also"
+            or self.env.config.matlab_auto_link == "all"
+        ):
             see_also_re = re.compile(r"(See also:?\s*)(\b.*\b)(.*)", re.IGNORECASE)
             see_also_cond_re = re.compile(r"(\s*)(\b.*\b)(.*)")
             is_see_also_line = False
@@ -230,8 +233,8 @@ class MatlabDocumenter(PyDocumenter):
                             match.group(1) + ", ".join(entries) + match.group(3)
                         )
 
-        # replace everywhere
-        elif self.env.config.matlab_auto_link == "all":
+        # auto-link everywhere
+        if self.env.config.matlab_auto_link == "all":
             for n, o in entities_table.items():
                 role = o.ref_role()
                 if role in ["class", "func"]:

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -1334,9 +1334,6 @@ class MatClass(MatMixin, MatObject):
         """Returns full name for class object, for use as link target"""
         modname = self.__module__
         classname = self.name
-        if not env.config.matlab_keep_package_prefix:
-            modname = strip_package_prefix(modname)
-
         if env.config.matlab_short_links:
             # modname is only used for package names
             # - "target.+package" => "package"
@@ -1344,6 +1341,9 @@ class MatClass(MatMixin, MatObject):
             parts = modname.split(".")
             parts = [part for part in parts if part.startswith("+")]
             modname = ".".join(parts)
+
+        if not env.config.matlab_keep_package_prefix:
+            modname = strip_package_prefix(modname)
 
         return f"{modname}.{classname}".lstrip(".")
 

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -191,6 +191,10 @@ class MatObject(object):
         #: name of MATLAB object
         self.name = name
 
+    def ref_role(self):
+        # role to use for references to this object (e.g. when generating auto-links)
+        return "ref"
+
     @property
     def __name__(self):
         return self.name
@@ -429,6 +433,10 @@ class MatModule(MatObject):
         self.package = package
         #: entities found in the module: class, function, module (subpath and +package)
         self.entities = []
+
+    def ref_role(self):
+        # role to use for references to this object (e.g. when generating auto-links)
+        return "mod"
 
     def safe_getmembers(self):
         logger.debug(
@@ -841,6 +849,10 @@ class MatFunction(MatObject):
         # if there are any tokens left save them
         if len(tks) > 0:
             self.rem_tks = tks  # save extra tokens
+
+    def ref_role(self):
+        # role to use for references to this object (e.g. when generating auto-links)
+        return "func"
 
     @property
     def __doc__(self):
@@ -1306,6 +1318,10 @@ class MatClass(MatMixin, MatObject):
 
         self.rem_tks = idx  # index of last token
 
+    def ref_role(self):
+        # role to use for references to this object (e.g. when generating auto-links)
+        return "class"
+
     def attributes(self, idx, attr_types):
         """
         Retrieve MATLAB class, property and method attributes.
@@ -1460,6 +1476,10 @@ class MatProperty(MatObject):
         self.docstring = attrs["docstring"]
         # self.class = attrs['class']
 
+    def ref_role(self):
+        # role to use for references to this object (e.g. when generating auto-links)
+        return "attr"
+
     @property
     def __doc__(self):
         return self.docstring
@@ -1471,6 +1491,10 @@ class MatMethod(MatFunction):
         super(MatMethod, self).__init__(None, modname, tks)
         self.cls = cls
         self.attrs = attrs
+
+    def ref_role(self):
+        # role to use for references to this object (e.g. when generating auto-links)
+        return "meth"
 
     def skip_tokens(self):
         # Number of tokens to skip in `MatClass`

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -200,7 +200,7 @@ class MatObject(object):
         self.name = name
 
     def ref_role(self):
-        # role to use for references to this object (e.g. when generating auto-links)
+        """Returns role to use for references to this object (e.g. when generating auto-links)"""
         return "ref"
 
     @property
@@ -443,7 +443,7 @@ class MatModule(MatObject):
         self.entities = []
 
     def ref_role(self):
-        # role to use for references to this object (e.g. when generating auto-links)
+        """Returns role to use for references to this object (e.g. when generating auto-links)"""
         return "mod"
 
     def safe_getmembers(self):
@@ -859,7 +859,7 @@ class MatFunction(MatObject):
             self.rem_tks = tks  # save extra tokens
 
     def ref_role(self):
-        # role to use for references to this object (e.g. when generating auto-links)
+        """Returns role to use for references to this object (e.g. when generating auto-links)"""
         return "func"
 
     @property
@@ -1327,8 +1327,32 @@ class MatClass(MatMixin, MatObject):
         self.rem_tks = idx  # index of last token
 
     def ref_role(self):
-        # role to use for references to this object (e.g. when generating auto-links)
+        """Returns role to use for references to this object (e.g. when generating auto-links)"""
         return "class"
+
+    def fullname(self, env):
+        """Returns full name for class object, for use as link target"""
+        modname = self.__module__
+        classname = self.name
+        if not env.config.matlab_keep_package_prefix:
+            modname = strip_package_prefix(modname)
+
+        if env.config.matlab_short_links:
+            # modname is only used for package names
+            # - "target.+package" => "package"
+            # - "target" => ""
+            parts = modname.split(".")
+            parts = [part for part in parts if part.startswith("+")]
+            modname = ".".join(parts)
+
+        return f"{modname}.{classname}"
+
+    def link(self, env, name):
+        """Returns link for class object"""
+        if not name:
+            name = self.name
+        target = self.fullname(env)
+        return f":class:`{name}<{target}>`"
 
     def attributes(self, idx, attr_types):
         """
@@ -1485,7 +1509,7 @@ class MatProperty(MatObject):
         # self.class = attrs['class']
 
     def ref_role(self):
-        # role to use for references to this object (e.g. when generating auto-links)
+        """Returns role to use for references to this object (e.g. when generating auto-links)"""
         return "attr"
 
     @property
@@ -1501,7 +1525,7 @@ class MatMethod(MatFunction):
         self.attrs = attrs
 
     def ref_role(self):
-        # role to use for references to this object (e.g. when generating auto-links)
+        """Returns role to use for references to this object (e.g. when generating auto-links)"""
         return "meth"
 
     def skip_tokens(self):

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -51,6 +51,12 @@ __all__ = [
 #   Will result in a short name of: package.ClassBar
 entities_table = {}
 
+# Dictionary containing a map of names WITHOUT '+' in package names to
+# the corresponding names WITH '+' in the package name. This is only
+# used if "matlab_auto_link" is on AND "matlab_keep_package_prefix"
+# is True AND a docstring with "see also" is encountered.
+entities_name_map = {}
+
 
 def shortest_name(dotted_path):
     # Creates the shortest valid MATLAB name from a dotted path
@@ -108,6 +114,7 @@ def populate_entities_table(obj, path=""):
         fullpath = path + "." + o.name
         fullpath = fullpath.lstrip(".")
         entities_table[fullpath] = o
+        entities_name_map[strip_package_prefix(fullpath)] = fullpath
         if isinstance(o, MatModule):
             if o.entities:
                 populate_entities_table(o, fullpath)
@@ -152,6 +159,7 @@ def analyze(app):
         short_name = shortest_name(name)
         if short_name != name:
             short_names[short_name] = entity
+            entities_name_map[short_name] = short_name
 
     entities_table.update(short_names)
 

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -1347,12 +1347,13 @@ class MatClass(MatMixin, MatObject):
 
         return f"{modname}.{classname}".lstrip(".")
 
-    def link(self, env, name):
+    def link(self, env, name=None):
         """Returns link for class object"""
-        if not name:
-            name = self.name
         target = self.fullname(env)
-        return f":class:`{name} <{target}>`"
+        if name:
+            return f":class:`{name} <{target}>`"
+        else:
+            return f":class:`{target}`"
 
     def attributes(self, idx, attr_types):
         """

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -1345,7 +1345,7 @@ class MatClass(MatMixin, MatObject):
             parts = [part for part in parts if part.startswith("+")]
             modname = ".".join(parts)
 
-        return f"{modname}.{classname}"
+        return f"{modname}.{classname}".lstrip(".")
 
     def link(self, env, name):
         """Returns link for class object"""

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -1352,7 +1352,7 @@ class MatClass(MatMixin, MatObject):
         if not name:
             name = self.name
         target = self.fullname(env)
-        return f":class:`{name}<{target}>`"
+        return f":class:`{name} <{target}>`"
 
     def attributes(self, idx, attr_types):
         """

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -863,7 +863,7 @@ def setup(app):
     app.add_config_value("matlab_keep_package_prefix", False, "env")
     app.add_config_value("matlab_show_property_default_value", False, "env")
     app.add_config_value("matlab_short_links", False, "env")
-    app.add_config_value("matlab_auto_link", False, "env")
+    app.add_config_value("matlab_auto_link", None, "env")
 
     app.registry.add_documenter("mat:module", doc.MatModuleDocumenter)
     app.add_directive_to_domain(

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -845,6 +845,11 @@ def analyze(app):
 
 
 def ensure_configuration(app, env):
+    if env.matlab_auto_link:
+        logger.info(
+            f"[sphinxcontrib-matlabdomain] matlab_auto_link='{env.matlab_auto_link}', forcing matlab_short_links=True."
+        )
+        env.matlab_short_links = True
     if env.matlab_short_links:
         logger.info(
             "[sphinxcontrib-matlabdomain] matlab_short_links=True, forcing matlab_keep_package_prefix=False."

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -863,6 +863,7 @@ def setup(app):
     app.add_config_value("matlab_keep_package_prefix", False, "env")
     app.add_config_value("matlab_show_property_default_value", False, "env")
     app.add_config_value("matlab_short_links", False, "env")
+    app.add_config_value("matlab_auto_link", False, "env")
 
     app.registry.add_documenter("mat:module", doc.MatModuleDocumenter)
     app.add_directive_to_domain(

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -845,11 +845,6 @@ def analyze(app):
 
 
 def ensure_configuration(app, env):
-    if env.matlab_auto_link:
-        logger.info(
-            f"[sphinxcontrib-matlabdomain] matlab_auto_link='{env.matlab_auto_link}', forcing matlab_short_links=True."
-        )
-        env.matlab_short_links = True
     if env.matlab_short_links:
         logger.info(
             "[sphinxcontrib-matlabdomain] matlab_short_links=True, forcing matlab_keep_package_prefix=False."

--- a/tests/roots/test_autodoc/BaseClass.m
+++ b/tests/roots/test_autodoc/BaseClass.m
@@ -2,7 +2,7 @@ classdef BaseClass
 % A class in the very root of the directory
 %
 % See Also
-%    ClassExample, baseFunction
+%    target.ClassExample, baseFunction
 
 methods
     function obj = BaseClass(obj,args)

--- a/tests/roots/test_autodoc/BaseClass.m
+++ b/tests/roots/test_autodoc/BaseClass.m
@@ -2,7 +2,7 @@ classdef BaseClass
 % A class in the very root of the directory
 %
 % See Also
-%    target.ClassExample, baseFunction
+%    target.ClassExample, baseFunction, ClassExample
 
 methods
     function obj = BaseClass(obj,args)

--- a/tests/roots/test_autodoc/BaseClass.m
+++ b/tests/roots/test_autodoc/BaseClass.m
@@ -1,6 +1,11 @@
 classdef BaseClass
 % A class in the very root of the directory
 %
+% BaseClass Methods:
+%   BaseClass - the constructor, whose description extends
+%       to the next line
+%   DoBase - another BaseClass method
+%
 % See Also
 %    target.ClassExample, baseFunction, ClassExample
 

--- a/tests/roots/test_autodoc/BaseClass.m
+++ b/tests/roots/test_autodoc/BaseClass.m
@@ -1,5 +1,8 @@
 classdef BaseClass
 % A class in the very root of the directory
+%
+% See Also
+%    ClassExample, baseFunction
 
 methods
     function obj = BaseClass(obj,args)

--- a/tests/roots/test_autodoc/baseFunction.m
+++ b/tests/roots/test_autodoc/baseFunction.m
@@ -2,7 +2,7 @@ function y = baseFunction(x)
 % Return the base of x
 %
 % See Also:
-%     ClassMeow
-%     package.ClassBar
+%     target.submodule.ClassMeow
+%     target.package.ClassBar
 
 y = x;

--- a/tests/roots/test_autodoc/baseFunction.m
+++ b/tests/roots/test_autodoc/baseFunction.m
@@ -1,3 +1,8 @@
 function y = baseFunction(x)
 % Return the base of x
+%
+% See Also:
+%     ClassMeow
+%     package.ClassBar
+
 y = x;

--- a/tests/roots/test_autodoc/baseFunction.m
+++ b/tests/roots/test_autodoc/baseFunction.m
@@ -4,5 +4,7 @@ function y = baseFunction(x)
 % See Also:
 %     target.submodule.ClassMeow
 %     target.package.ClassBar
+%     ClassMeow
+%     package.ClassBar
 
 y = x;

--- a/tests/roots/test_autodoc/target/+package/ClassBar.m
+++ b/tests/roots/test_autodoc/target/+package/ClassBar.m
@@ -1,10 +1,10 @@
 classdef ClassBar < handle
-% The Bar and Foo handler
+% The Bar and Foo handler, with a doFoo() method.
 
     properties
         bars = 'bars' % Number of bars
 
-        % Number of foos
+        % Number of foos, used by doBar() method
         foos = 10
     end
 
@@ -20,7 +20,7 @@ classdef ClassBar < handle
         end
 
         function doBar(obj)
-            % Doing bar
+            % Doing bar, not called by ClassBar()
         end
     end
 end

--- a/tests/roots/test_autodoc/target/+package/funcFoo.m
+++ b/tests/roots/test_autodoc/target/+package/funcFoo.m
@@ -1,5 +1,10 @@
 function [x, y] = funcFoo(u, t)
 % Function that does Foo
+% ::
 %
+%   x = package.funcFoo(u)
+%   [x, y] = package.funcFoo(u, t)
+%
+% Test for auto-linking with baseFunction and BaseClass, etc.
 x = u;
 y = t;

--- a/tests/roots/test_autodoc/target/ClassExample.m
+++ b/tests/roots/test_autodoc/target/ClassExample.m
@@ -5,7 +5,7 @@ classdef ClassExample < handle
     % :param b: second property of :class:`ClassExample`
     % :param c: third property of :class:`ClassExample`
     %
-    % See also BaseClass, baseFunction.
+    % See also BaseClass, baseFunction, unknownEntity.
 
     properties
         a % a property

--- a/tests/roots/test_autodoc/target/ClassExample.m
+++ b/tests/roots/test_autodoc/target/ClassExample.m
@@ -1,9 +1,13 @@
 classdef ClassExample < handle
     % Example class
     %
-    % :param a: first property of :class:`ClassExample`
-    % :param b: second property of :class:`ClassExample`
-    % :param c: third property of :class:`ClassExample`
+    % ClassExample Properties:
+    %   a - first property of ClassExample
+    %   b - second property of ClassExample
+    %   c - third property of ClassExample
+    % ClassExample Methods:
+    %   ClassExample - the constructor
+    %   mymethod - a method in ClassExample
     %
     % See also BaseClass, baseFunction, unknownEntity.
 

--- a/tests/roots/test_autodoc/target/ClassExample.m
+++ b/tests/roots/test_autodoc/target/ClassExample.m
@@ -6,7 +6,7 @@ classdef ClassExample < handle
     %   b - second property of ClassExample
     %   c - third property of ClassExample
     % ClassExample Methods:
-    %   ClassExample - the constructor
+    %   ClassExample - the constructor and a reference to mymethod()
     %   mymethod - a method in ClassExample
     %
     % See also BaseClass, baseFunction, unknownEntity.

--- a/tests/roots/test_autodoc/target/ClassExample.m
+++ b/tests/roots/test_autodoc/target/ClassExample.m
@@ -4,6 +4,8 @@ classdef ClassExample < handle
     % :param a: first property of :class:`ClassExample`
     % :param b: second property of :class:`ClassExample`
     % :param c: third property of :class:`ClassExample`
+    %
+    % See also BaseClass, baseFunction.
 
     properties
         a % a property

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -31,10 +31,20 @@ def test_target(make_app, rootdir):
     app.builder.build_all()
 
     content = pickle.loads((app.doctreedir / "index_target.doctree").read_bytes())
+    property_section = content[0][2][1][2][0]  # a bit fragile, I know
+    method_section = content[0][2][1][2][1]  # a bit fragile, I know
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nParameters\n\na – first property of ClassExample\n\nb – second property of ClassExample\n\nc – third property of ClassExample\n\nSee also BaseClass, baseFunction, unknownEntity.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb\n\na property with default value\n\n\n\nc\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
+        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nClassExample Properties:\n\na - first property of ClassExample\nb - second property of ClassExample\nc - third property of ClassExample\n\nClassExample Methods:\n\nClassExample - the constructor\nmymethod - a method in ClassExample\n\nSee also BaseClass, baseFunction, unknownEntity.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb\n\na property with default value\n\n\n\nc\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
+    )
+    assert (
+        property_section.rawsource
+        == "ClassExample Properties:\na - first property of ClassExample\nb - second property of ClassExample\nc - third property of ClassExample"
+    )
+    assert (
+        method_section.rawsource
+        == "ClassExample Methods:\nClassExample - the constructor\nmymethod - a method in ClassExample\n"
     )
 
 
@@ -46,23 +56,43 @@ def test_target_show_default_value(make_app, rootdir):
     app.builder.build_all()
 
     content = pickle.loads((app.doctreedir / "index_target.doctree").read_bytes())
+    property_section = content[0][2][1][2][0]  # a bit fragile, I know
+    method_section = content[0][2][1][2][1]  # a bit fragile, I know
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nParameters\n\na – first property of ClassExample\n\nb – second property of ClassExample\n\nc – third property of ClassExample\n\nSee also BaseClass, baseFunction, unknownEntity.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb = 10\n\na property with default value\n\n\n\nc = [10; ... 30]\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
+        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nClassExample Properties:\n\na - first property of ClassExample\nb - second property of ClassExample\nc - third property of ClassExample\n\nClassExample Methods:\n\nClassExample - the constructor\nmymethod - a method in ClassExample\n\nSee also BaseClass, baseFunction, unknownEntity.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb = 10\n\na property with default value\n\n\n\nc = [10; ... 30]\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
+    )
+    assert (
+        property_section.rawsource
+        == "ClassExample Properties:\na - first property of ClassExample\nb - second property of ClassExample\nc - third property of ClassExample"
+    )
+    assert (
+        method_section.rawsource
+        == "ClassExample Methods:\nClassExample - the constructor\nmymethod - a method in ClassExample\n"
     )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
-def test_target_auto_link_see_also(make_app, rootdir):
+def test_target_auto_link_basic(make_app, rootdir):
     srcdir = rootdir / "roots" / "test_autodoc"
     confdict = {"matlab_auto_link": "basic"}
     app = make_app(srcdir=srcdir, confoverrides=confdict)
     app.builder.build_all()
 
     content = pickle.loads((app.doctreedir / "index_target.doctree").read_bytes())
+    property_section = content[0][2][1][2][0]  # a bit fragile, I know
+    method_section = content[0][2][1][2][1]  # a bit fragile, I know
     see_also_line = content[0][2][1][3]  # a bit fragile, I know
     assert len(content) == 1
+    assert (
+        property_section.rawsource
+        == "ClassExample Properties:\n* :attr:`a <target.ClassExample.a>` - first property of ClassExample\n* :attr:`b <target.ClassExample.b>` - second property of ClassExample\n* :attr:`c <target.ClassExample.c>` - third property of ClassExample"
+    )
+    assert (
+        method_section.rawsource
+        == "ClassExample Methods:\n* :meth:`ClassExample <target.ClassExample.ClassExample>` - the constructor\n* :meth:`mymethod <target.ClassExample.mymethod>` - a method in ClassExample\n"
+    )
     assert (
         see_also_line.rawsource
         == "See also :class:`BaseClass`, :func:`baseFunction`, ``unknownEntity``."
@@ -154,7 +184,7 @@ def test_root(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nSee Also\n\ntarget.ClassExample, baseFunction, ClassExample\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\ntarget.submodule.ClassMeow\ntarget.package.ClassBar\nClassMeow\npackage.ClassBar"
+        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nBaseClass Methods:\n\nBaseClass - the constructor, whose description extends\n\nto the next line\n\nDoBase - another BaseClass method\n\nSee Also\n\ntarget.ClassExample, baseFunction, ClassExample\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\ntarget.submodule.ClassMeow\ntarget.package.ClassBar\nClassMeow\npackage.ClassBar"
     )
 
 
@@ -169,21 +199,26 @@ def test_root_show_default_value(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nSee Also\n\ntarget.ClassExample, baseFunction, ClassExample\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\ntarget.submodule.ClassMeow\ntarget.package.ClassBar\nClassMeow\npackage.ClassBar"
+        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nBaseClass Methods:\n\nBaseClass - the constructor, whose description extends\n\nto the next line\n\nDoBase - another BaseClass method\n\nSee Also\n\ntarget.ClassExample, baseFunction, ClassExample\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\ntarget.submodule.ClassMeow\ntarget.package.ClassBar\nClassMeow\npackage.ClassBar"
     )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
-def test_root_auto_link_see_also(make_app, rootdir):
+def test_root_auto_link_basic(make_app, rootdir):
     srcdir = rootdir / "roots" / "test_autodoc"
     confdict = {"matlab_auto_link": "basic"}
     app = make_app(srcdir=srcdir, confoverrides=confdict)
     app.builder.build_all()
 
     content = pickle.loads((app.doctreedir / "index_root.doctree").read_bytes())
-    see_also_line_1 = content[0][2][1][1][0]  # a bit fragile, I know
+    method_section = content[0][2][1][1][0]  # a bit fragile, I know
+    see_also_line_1 = content[0][2][1][1][1]  # a bit fragile, I know
     see_also_line_2 = content[0][4][1][1][0]  # a bit fragile, I know
     assert len(content) == 1
+    assert (
+        method_section.rawsource
+        == "BaseClass Methods:\n* :meth:`BaseClass <BaseClass.BaseClass>` - the constructor, whose description extends\n    to the next line\n* :meth:`DoBase <BaseClass.DoBase>` - another BaseClass method\n"
+    )
     assert (
         see_also_line_1.rawsource
         == "See Also\n:class:`target.ClassExample`, :func:`baseFunction`, :class:`ClassExample`\n\n"

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -41,9 +41,8 @@ def test_target(make_app, rootdir):
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_target_show_default_value(make_app, rootdir):
     srcdir = rootdir / "roots" / "test_autodoc"
-    app = make_app(
-        srcdir=srcdir, confoverrides={"matlab_show_property_default_value": True}
-    )
+    confdict = {"matlab_show_property_default_value": True}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
     app.builder.build_all()
 
     content = pickle.loads((app.doctreedir / "index_target.doctree").read_bytes())
@@ -57,7 +56,8 @@ def test_target_show_default_value(make_app, rootdir):
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_target_auto_link_see_also(make_app, rootdir):
     srcdir = rootdir / "roots" / "test_autodoc"
-    app = make_app(srcdir=srcdir, confoverrides={"matlab_auto_link": "see_also"})
+    confdict = {"matlab_auto_link": "see_also"}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
     app.builder.build_all()
 
     content = pickle.loads((app.doctreedir / "index_target.doctree").read_bytes())
@@ -99,9 +99,8 @@ def test_package(make_app, rootdir):
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_package_show_default_value(make_app, rootdir):
     srcdir = rootdir / "roots" / "test_autodoc"
-    app = make_app(
-        srcdir=srcdir, confoverrides={"matlab_show_property_default_value": True}
-    )
+    confdict = {"matlab_show_property_default_value": True}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
     app.builder.build_all()
 
     content = pickle.loads((app.doctreedir / "index_package.doctree").read_bytes())
@@ -129,6 +128,8 @@ def test_submodule(make_app, rootdir):
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_submodule_show_default_value(make_app, rootdir):
     srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_auto_link": "see_also"}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
     app = make_app(
         srcdir=srcdir, confoverrides={"matlab_show_property_default_value": True}
     )
@@ -152,30 +153,30 @@ def test_root(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nSee Also\n\ntarget.ClassExample, baseFunction\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\ntarget.submodule.ClassMeow\ntarget.package.ClassBar"
+        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nSee Also\n\ntarget.ClassExample, baseFunction, ClassExample\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\ntarget.submodule.ClassMeow\ntarget.package.ClassBar\nClassMeow\npackage.ClassBar"
     )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_root_show_default_value(make_app, rootdir):
     srcdir = rootdir / "roots" / "test_autodoc"
-    app = make_app(
-        srcdir=srcdir, confoverrides={"matlab_show_property_default_value": True}
-    )
+    confdict = {"matlab_show_property_default_value": True}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
     app.builder.build_all()
 
     content = pickle.loads((app.doctreedir / "index_root.doctree").read_bytes())
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nSee Also\n\ntarget.ClassExample, baseFunction\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\ntarget.submodule.ClassMeow\ntarget.package.ClassBar"
+        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nSee Also\n\ntarget.ClassExample, baseFunction, ClassExample\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\ntarget.submodule.ClassMeow\ntarget.package.ClassBar\nClassMeow\npackage.ClassBar"
     )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_root_auto_link_see_also(make_app, rootdir):
     srcdir = rootdir / "roots" / "test_autodoc"
-    app = make_app(srcdir=srcdir, confoverrides={"matlab_auto_link": "see_also"})
+    confdict = {"matlab_auto_link": "see_also"}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
     app.builder.build_all()
 
     content = pickle.loads((app.doctreedir / "index_root.doctree").read_bytes())
@@ -184,11 +185,11 @@ def test_root_auto_link_see_also(make_app, rootdir):
     assert len(content) == 1
     assert (
         see_also_line_1.rawsource
-        == "See Also\n:class:`target.ClassExample`, :func:`baseFunction`\n\n"
+        == "See Also\n:class:`target.ClassExample`, :func:`baseFunction`, :class:`ClassExample`\n\n"
     )
     assert (
         see_also_line_2.rawsource
-        == "See Also:\n:class:`target.submodule.ClassMeow`\n:class:`target.package.ClassBar`"
+        == "See Also:\n:class:`target.submodule.ClassMeow`\n:class:`target.package.ClassBar`\n:class:`ClassMeow`\n:class:`package.ClassBar`"
     )
 
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -36,7 +36,7 @@ def test_target(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nClassExample Properties:\n\na - first property of ClassExample\nb - second property of ClassExample\nc - third property of ClassExample\n\nClassExample Methods:\n\nClassExample - the constructor\nmymethod - a method in ClassExample\n\nSee also BaseClass, baseFunction, unknownEntity.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb\n\na property with default value\n\n\n\nc\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
+        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nClassExample Properties:\n\na - first property of ClassExample\nb - second property of ClassExample\nc - third property of ClassExample\n\nClassExample Methods:\n\nClassExample - the constructor and a reference to mymethod()\nmymethod - a method in ClassExample\n\nSee also BaseClass, baseFunction, unknownEntity.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb\n\na property with default value\n\n\n\nc\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
     )
     assert (
         property_section.rawsource
@@ -44,7 +44,7 @@ def test_target(make_app, rootdir):
     )
     assert (
         method_section.rawsource
-        == "ClassExample Methods:\nClassExample - the constructor\nmymethod - a method in ClassExample\n"
+        == "ClassExample Methods:\nClassExample - the constructor and a reference to mymethod()\nmymethod - a method in ClassExample\n"
     )
 
 
@@ -61,7 +61,7 @@ def test_target_show_default_value(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nClassExample Properties:\n\na - first property of ClassExample\nb - second property of ClassExample\nc - third property of ClassExample\n\nClassExample Methods:\n\nClassExample - the constructor\nmymethod - a method in ClassExample\n\nSee also BaseClass, baseFunction, unknownEntity.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb = 10\n\na property with default value\n\n\n\nc = [10; ... 30]\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
+        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nClassExample Properties:\n\na - first property of ClassExample\nb - second property of ClassExample\nc - third property of ClassExample\n\nClassExample Methods:\n\nClassExample - the constructor and a reference to mymethod()\nmymethod - a method in ClassExample\n\nSee also BaseClass, baseFunction, unknownEntity.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb = 10\n\na property with default value\n\n\n\nc = [10; ... 30]\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
     )
     assert (
         property_section.rawsource
@@ -69,7 +69,7 @@ def test_target_show_default_value(make_app, rootdir):
     )
     assert (
         method_section.rawsource
-        == "ClassExample Methods:\nClassExample - the constructor\nmymethod - a method in ClassExample\n"
+        == "ClassExample Methods:\nClassExample - the constructor and a reference to mymethod()\nmymethod - a method in ClassExample\n"
     )
 
 
@@ -91,7 +91,7 @@ def test_target_auto_link_basic(make_app, rootdir):
     )
     assert (
         method_section.rawsource
-        == "ClassExample Methods:\n* :meth:`ClassExample() <target.ClassExample.ClassExample>` - the constructor\n* :meth:`mymethod() <target.ClassExample.mymethod>` - a method in ClassExample\n"
+        == "ClassExample Methods:\n* :meth:`ClassExample() <target.ClassExample.ClassExample>` - the constructor and a reference to mymethod()\n* :meth:`mymethod() <target.ClassExample.mymethod>` - a method in ClassExample\n"
     )
     assert (
         see_also_line.rawsource
@@ -117,7 +117,7 @@ def test_target_auto_link_all(make_app, rootdir):
     )
     assert (
         method_section.rawsource
-        == "ClassExample Methods:\n* :meth:`ClassExample() <target.ClassExample.ClassExample>` - the constructor\n* :meth:`mymethod() <target.ClassExample.mymethod>` - a method in :class:`ClassExample`\n"
+        == "ClassExample Methods:\n* :meth:`ClassExample() <target.ClassExample.ClassExample>` - the constructor and a reference to :meth:`mymethod() <target.ClassExample.mymethod>`\n* :meth:`mymethod() <target.ClassExample.mymethod>` - a method in :class:`ClassExample`\n"
     )
     assert (
         see_also_line.rawsource
@@ -146,11 +146,17 @@ def test_package(make_app, rootdir):
     app.builder.build_all()
 
     content = pickle.loads((app.doctreedir / "index_package.doctree").read_bytes())
+    docstring1 = content[0][2][1][1]  # a bit fragile, I know
+    docstring2 = content[0][2][1][2][0][1][1][4][1][0]  # a bit fragile, I know
+    docstring3 = content[0][2][1][2][0][2][1][2][1][0]  # a bit fragile, I know
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "package\n\n\n\nclass target.package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars\n\nNumber of bars\n\n\n\nfoos\n\nNumber of foos\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\ntarget.package.funcFoo(u, t)\n\nFunction that does Foo"
+        == "package\n\n\n\nclass target.package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars\n\nNumber of bars\n\n\n\nfoos\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\ntarget.package.funcFoo(u, t)\n\nFunction that does Foo"
     )
+    assert docstring1.rawsource == "The Bar and Foo handler, with a doFoo() method."
+    assert docstring2.rawsource == "Number of foos, used by doBar() method"
+    assert docstring3.rawsource == "Doing bar, not called by ClassBar()"
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
@@ -164,7 +170,37 @@ def test_package_show_default_value(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "package\n\n\n\nclass target.package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars = 'bars'\n\nNumber of bars\n\n\n\nfoos = 10\n\nNumber of foos\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\ntarget.package.funcFoo(u, t)\n\nFunction that does Foo"
+        == "package\n\n\n\nclass target.package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars = 'bars'\n\nNumber of bars\n\n\n\nfoos = 10\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\ntarget.package.funcFoo(u, t)\n\nFunction that does Foo"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_package_auto_link_all(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_auto_link": "all"}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_package.doctree").read_bytes())
+    docstring1 = content[0][2][1][1]  # a bit fragile, I know
+    docstring2 = content[0][2][1][2][0][1][1][4][1][0]  # a bit fragile, I know
+    docstring3 = content[0][2][1][2][0][2][1][2][1][0]  # a bit fragile, I know
+    assert len(content) == 1
+    assert (
+        content[0].astext()
+        == "package\n\n\n\nclass target.package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars\n\nNumber of bars\n\n\n\nfoos\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\ntarget.package.funcFoo(u, t)\n\nFunction that does Foo"
+    )
+    assert (
+        docstring1.rawsource
+        == "The Bar and Foo handler, with a :meth:`doFoo() <target.package.ClassBar.doFoo>` method."
+    )
+    assert (
+        docstring2.rawsource
+        == "Number of foos, used by :meth:`doBar() <target.package.ClassBar.doBar>` method"
+    )
+    assert (
+        docstring3.rawsource
+        == "Doing bar, not called by :meth:`ClassBar() <target.package.ClassBar.ClassBar>`"
     )
 
 
@@ -175,21 +211,23 @@ def test_submodule(make_app, rootdir):
     app.builder.build_all()
 
     content = pickle.loads((app.doctreedir / "index_submodule.doctree").read_bytes())
+    bases_line = content[0][2][1][0]
     assert len(content) == 1
     assert (
         content[0].astext()
         == "submodule\n\n\n\nclass target.submodule.ClassMeow\n\nBases: package.ClassBar\n\nClass which inherits from a package\n\nMethod Summary\n\n\n\n\n\nsay()\n\nSay Meow\n\n\n\ntarget.submodule.funcMeow(input)\n\nTests a function with comments after docstring"
+    )
+    assert (
+        bases_line.rawsource
+        == "Bases: :class:`package.ClassBar <target.package.ClassBar>`"
     )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_submodule_show_default_value(make_app, rootdir):
     srcdir = rootdir / "roots" / "test_autodoc"
-    confdict = {"matlab_auto_link": "basic"}
+    confdict = {"matlab_show_property_default_value": True}
     app = make_app(srcdir=srcdir, confoverrides=confdict)
-    app = make_app(
-        srcdir=srcdir, confoverrides={"matlab_show_property_default_value": True}
-    )
     app.builder.build_all()
 
     content = pickle.loads((app.doctreedir / "index_submodule.doctree").read_bytes())

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -215,12 +215,9 @@ def test_submodule(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "submodule\n\n\n\nclass target.submodule.ClassMeow\n\nBases: package.ClassBar\n\nClass which inherits from a package\n\nMethod Summary\n\n\n\n\n\nsay()\n\nSay Meow\n\n\n\ntarget.submodule.funcMeow(input)\n\nTests a function with comments after docstring"
+        == "submodule\n\n\n\nclass target.submodule.ClassMeow\n\nBases: target.package.ClassBar\n\nClass which inherits from a package\n\nMethod Summary\n\n\n\n\n\nsay()\n\nSay Meow\n\n\n\ntarget.submodule.funcMeow(input)\n\nTests a function with comments after docstring"
     )
-    assert (
-        bases_line.rawsource
-        == "Bases: :class:`package.ClassBar <target.package.ClassBar>`"
-    )
+    assert bases_line.rawsource == "Bases: :class:`target.package.ClassBar`"
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
@@ -234,7 +231,7 @@ def test_submodule_show_default_value(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "submodule\n\n\n\nclass target.submodule.ClassMeow\n\nBases: package.ClassBar\n\nClass which inherits from a package\n\nMethod Summary\n\n\n\n\n\nsay()\n\nSay Meow\n\n\n\ntarget.submodule.funcMeow(input)\n\nTests a function with comments after docstring"
+        == "submodule\n\n\n\nclass target.submodule.ClassMeow\n\nBases: target.package.ClassBar\n\nClass which inherits from a package\n\nMethod Summary\n\n\n\n\n\nsay()\n\nSay Meow\n\n\n\ntarget.submodule.funcMeow(input)\n\nTests a function with comments after docstring"
     )
 
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -152,7 +152,7 @@ def test_package(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "package\n\n\n\nclass target.package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars\n\nNumber of bars\n\n\n\nfoos\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\ntarget.package.funcFoo(u, t)\n\nFunction that does Foo"
+        == "package\n\n\n\nclass target.package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars\n\nNumber of bars\n\n\n\nfoos\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\ntarget.package.funcFoo(u, t)\n\nFunction that does Foo\n\nx = package.funcFoo(u)\n[x, y] = package.funcFoo(u, t)\n\nTest for auto-linking with baseFunction and BaseClass, etc."
     )
     assert docstring1.rawsource == "The Bar and Foo handler, with a doFoo() method."
     assert docstring2.rawsource == "Number of foos, used by doBar() method"
@@ -170,7 +170,7 @@ def test_package_show_default_value(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "package\n\n\n\nclass target.package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars = 'bars'\n\nNumber of bars\n\n\n\nfoos = 10\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\ntarget.package.funcFoo(u, t)\n\nFunction that does Foo"
+        == "package\n\n\n\nclass target.package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars = 'bars'\n\nNumber of bars\n\n\n\nfoos = 10\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\ntarget.package.funcFoo(u, t)\n\nFunction that does Foo\n\nx = package.funcFoo(u)\n[x, y] = package.funcFoo(u, t)\n\nTest for auto-linking with baseFunction and BaseClass, etc."
     )
 
 
@@ -188,7 +188,7 @@ def test_package_auto_link_all(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "package\n\n\n\nclass target.package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars\n\nNumber of bars\n\n\n\nfoos\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\ntarget.package.funcFoo(u, t)\n\nFunction that does Foo"
+        == "package\n\n\n\nclass target.package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars\n\nNumber of bars\n\n\n\nfoos\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\ntarget.package.funcFoo(u, t)\n\nFunction that does Foo\n\nx = package.funcFoo(u)\n[x, y] = package.funcFoo(u, t)\n\nTest for auto-linking with baseFunction() and BaseClass, etc."
     )
     assert (
         docstring1.rawsource

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -56,7 +56,7 @@ def test_target_show_default_value(make_app, rootdir):
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_target_auto_link_see_also(make_app, rootdir):
     srcdir = rootdir / "roots" / "test_autodoc"
-    confdict = {"matlab_auto_link": "see_also"}
+    confdict = {"matlab_auto_link": "basic"}
     app = make_app(srcdir=srcdir, confoverrides=confdict)
     app.builder.build_all()
 
@@ -129,7 +129,7 @@ def test_submodule(make_app, rootdir):
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_submodule_show_default_value(make_app, rootdir):
     srcdir = rootdir / "roots" / "test_autodoc"
-    confdict = {"matlab_auto_link": "see_also"}
+    confdict = {"matlab_auto_link": "basic"}
     app = make_app(srcdir=srcdir, confoverrides=confdict)
     app = make_app(
         srcdir=srcdir, confoverrides={"matlab_show_property_default_value": True}
@@ -176,7 +176,7 @@ def test_root_show_default_value(make_app, rootdir):
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_root_auto_link_see_also(make_app, rootdir):
     srcdir = rootdir / "roots" / "test_autodoc"
-    confdict = {"matlab_auto_link": "see_also"}
+    confdict = {"matlab_auto_link": "basic"}
     app = make_app(srcdir=srcdir, confoverrides=confdict)
     app.builder.build_all()
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -100,6 +100,32 @@ def test_target_auto_link_basic(make_app, rootdir):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_target_auto_link_all(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_auto_link": "all"}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_target.doctree").read_bytes())
+    property_section = content[0][2][1][2][0]  # a bit fragile, I know
+    method_section = content[0][2][1][2][1]  # a bit fragile, I know
+    see_also_line = content[0][2][1][3]  # a bit fragile, I know
+    assert len(content) == 1
+    assert (
+        property_section.rawsource
+        == "ClassExample Properties:\n* :attr:`a <target.ClassExample.a>` - first property of :class:`ClassExample`\n* :attr:`b <target.ClassExample.b>` - second property of :class:`ClassExample`\n* :attr:`c <target.ClassExample.c>` - third property of :class:`ClassExample`"
+    )
+    assert (
+        method_section.rawsource
+        == "ClassExample Methods:\n* :meth:`ClassExample <target.ClassExample.ClassExample>` - the constructor\n* :meth:`mymethod <target.ClassExample.mymethod>` - a method in :class:`ClassExample`\n"
+    )
+    assert (
+        see_also_line.rawsource
+        == "See also :class:`BaseClass`, :func:`baseFunction`, ``unknownEntity``."
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_classfolder(make_app, rootdir):
     srcdir = rootdir / "roots" / "test_autodoc"
     app = make_app(srcdir=srcdir)

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -34,7 +34,7 @@ def test_target(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nParameters\n\na – first property of ClassExample\n\nb – second property of ClassExample\n\nc – third property of ClassExample\n\nSee also BaseClass, baseFunction.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb\n\na property with default value\n\n\n\nc\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
+        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nParameters\n\na – first property of ClassExample\n\nb – second property of ClassExample\n\nc – third property of ClassExample\n\nSee also BaseClass, baseFunction, unknownEntity.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb\n\na property with default value\n\n\n\nc\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
     )
 
 
@@ -49,7 +49,7 @@ def test_target_show_default_value(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nParameters\n\na – first property of ClassExample\n\nb – second property of ClassExample\n\nc – third property of ClassExample\n\nSee also BaseClass, baseFunction.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb = 10\n\na property with default value\n\n\n\nc = [10; ... 30]\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
+        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nParameters\n\na – first property of ClassExample\n\nb – second property of ClassExample\n\nc – third property of ClassExample\n\nSee also BaseClass, baseFunction, unknownEntity.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb = 10\n\na property with default value\n\n\n\nc = [10; ... 30]\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
     )
 
 
@@ -64,7 +64,8 @@ def test_target_auto_link_see_also(make_app, rootdir):
     see_also_line = content[0][2][1][3]  # a bit fragile, I know
     assert len(content) == 1
     assert (
-        see_also_line.rawsource == "See also :class:`BaseClass`, :func:`baseFunction`."
+        see_also_line.rawsource
+        == "See also :class:`BaseClass`, :func:`baseFunction`, ``unknownEntity``."
     )
 
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -91,7 +91,7 @@ def test_target_auto_link_basic(make_app, rootdir):
     )
     assert (
         method_section.rawsource
-        == "ClassExample Methods:\n* :meth:`ClassExample <target.ClassExample.ClassExample>` - the constructor\n* :meth:`mymethod <target.ClassExample.mymethod>` - a method in ClassExample\n"
+        == "ClassExample Methods:\n* :meth:`ClassExample() <target.ClassExample.ClassExample>` - the constructor\n* :meth:`mymethod() <target.ClassExample.mymethod>` - a method in ClassExample\n"
     )
     assert (
         see_also_line.rawsource
@@ -117,7 +117,7 @@ def test_target_auto_link_all(make_app, rootdir):
     )
     assert (
         method_section.rawsource
-        == "ClassExample Methods:\n* :meth:`ClassExample <target.ClassExample.ClassExample>` - the constructor\n* :meth:`mymethod <target.ClassExample.mymethod>` - a method in :class:`ClassExample`\n"
+        == "ClassExample Methods:\n* :meth:`ClassExample() <target.ClassExample.ClassExample>` - the constructor\n* :meth:`mymethod() <target.ClassExample.mymethod>` - a method in :class:`ClassExample`\n"
     )
     assert (
         see_also_line.rawsource
@@ -243,7 +243,7 @@ def test_root_auto_link_basic(make_app, rootdir):
     assert len(content) == 1
     assert (
         method_section.rawsource
-        == "BaseClass Methods:\n* :meth:`BaseClass <BaseClass.BaseClass>` - the constructor, whose description extends\n    to the next line\n* :meth:`DoBase <BaseClass.DoBase>` - another BaseClass method\n"
+        == "BaseClass Methods:\n* :meth:`BaseClass() <BaseClass.BaseClass>` - the constructor, whose description extends\n    to the next line\n* :meth:`DoBase() <BaseClass.DoBase>` - another BaseClass method\n"
     )
     assert (
         see_also_line_1.rawsource

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -152,7 +152,7 @@ def test_root(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nSee Also\n\nClassExample, baseFunction\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\nClassMeow\npackage.ClassBar"
+        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nSee Also\n\ntarget.ClassExample, baseFunction\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\ntarget.submodule.ClassMeow\ntarget.package.ClassBar"
     )
 
 
@@ -168,7 +168,7 @@ def test_root_show_default_value(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nSee Also\n\nClassExample, baseFunction\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\nClassMeow\npackage.ClassBar"
+        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nSee Also\n\ntarget.ClassExample, baseFunction\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\ntarget.submodule.ClassMeow\ntarget.package.ClassBar"
     )
 
 
@@ -184,11 +184,11 @@ def test_root_auto_link_see_also(make_app, rootdir):
     assert len(content) == 1
     assert (
         see_also_line_1.rawsource
-        == "See Also\n:class:`ClassExample`, :func:`baseFunction`\n\n"
+        == "See Also\n:class:`target.ClassExample`, :func:`baseFunction`\n\n"
     )
     assert (
         see_also_line_2.rawsource
-        == "See Also:\n:class:`ClassMeow`\n:class:`package.ClassBar`"
+        == "See Also:\n:class:`target.submodule.ClassMeow`\n:class:`target.package.ClassBar`"
     )
 
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -34,7 +34,7 @@ def test_target(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nParameters\n\na – first property of ClassExample\n\nb – second property of ClassExample\n\nc – third property of ClassExample\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb\n\na property with default value\n\n\n\nc\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
+        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nParameters\n\na – first property of ClassExample\n\nb – second property of ClassExample\n\nc – third property of ClassExample\n\nSee also BaseClass, baseFunction.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb\n\na property with default value\n\n\n\nc\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
     )
 
 
@@ -50,7 +50,21 @@ def test_target_show_default_value(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nParameters\n\na – first property of ClassExample\n\nb – second property of ClassExample\n\nc – third property of ClassExample\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb = 10\n\na property with default value\n\n\n\nc = [10; ... 30]\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
+        == "target\n\n\n\nclass target.ClassExample(a)\n\nBases: handle\n\nExample class\n\nParameters\n\na – first property of ClassExample\n\nb – second property of ClassExample\n\nc – third property of ClassExample\n\nSee also BaseClass, baseFunction.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb = 10\n\na property with default value\n\n\n\nc = [10; ... 30]\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_target_auto_link_see_also(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    app = make_app(srcdir=srcdir, confoverrides={"matlab_auto_link": "see_also"})
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_target.doctree").read_bytes())
+    see_also_line = content[0][2][1][3]  # a bit fragile, I know
+    assert len(content) == 1
+    assert (
+        see_also_line.rawsource == "See also :class:`BaseClass`, :func:`baseFunction`."
     )
 
 
@@ -138,7 +152,7 @@ def test_root(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x"
+        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nSee Also\n\nClassExample, baseFunction\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\nClassMeow\npackage.ClassBar"
     )
 
 
@@ -154,7 +168,27 @@ def test_root_show_default_value(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x"
+        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nSee Also\n\nClassExample, baseFunction\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\nClassMeow\npackage.ClassBar"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_root_auto_link_see_also(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    app = make_app(srcdir=srcdir, confoverrides={"matlab_auto_link": "see_also"})
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_root.doctree").read_bytes())
+    see_also_line_1 = content[0][2][1][1][0]  # a bit fragile, I know
+    see_also_line_2 = content[0][4][1][1][0]  # a bit fragile, I know
+    assert len(content) == 1
+    assert (
+        see_also_line_1.rawsource
+        == "See Also\n:class:`ClassExample`, :func:`baseFunction`\n\n"
+    )
+    assert (
+        see_also_line_2.rawsource
+        == "See Also:\n:class:`ClassMeow`\n:class:`package.ClassBar`"
     )
 
 

--- a/tests/test_autodoc_short_links.py
+++ b/tests/test_autodoc_short_links.py
@@ -155,7 +155,7 @@ def test_package(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "package\n\n\n\nclass package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars\n\nNumber of bars\n\n\n\nfoos\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\npackage.funcFoo(u, t)\n\nFunction that does Foo"
+        == "package\n\n\n\nclass package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars\n\nNumber of bars\n\n\n\nfoos\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\npackage.funcFoo(u, t)\n\nFunction that does Foo\n\nx = package.funcFoo(u)\n[x, y] = package.funcFoo(u, t)\n\nTest for auto-linking with baseFunction and BaseClass, etc."
     )
     assert docstring1.rawsource == "The Bar and Foo handler, with a doFoo() method."
     assert docstring2.rawsource == "Number of foos, used by doBar() method"
@@ -173,7 +173,7 @@ def test_package_show_default_value(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "package\n\n\n\nclass package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars = 'bars'\n\nNumber of bars\n\n\n\nfoos = 10\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\npackage.funcFoo(u, t)\n\nFunction that does Foo"
+        == "package\n\n\n\nclass package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars = 'bars'\n\nNumber of bars\n\n\n\nfoos = 10\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\npackage.funcFoo(u, t)\n\nFunction that does Foo\n\nx = package.funcFoo(u)\n[x, y] = package.funcFoo(u, t)\n\nTest for auto-linking with baseFunction and BaseClass, etc."
     )
 
 
@@ -191,7 +191,7 @@ def test_package_auto_link_all(make_app, rootdir):
     assert len(content) == 1
     assert (
         content[0].astext()
-        == "package\n\n\n\nclass package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars\n\nNumber of bars\n\n\n\nfoos\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\npackage.funcFoo(u, t)\n\nFunction that does Foo"
+        == "package\n\n\n\nclass package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars\n\nNumber of bars\n\n\n\nfoos\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\npackage.funcFoo(u, t)\n\nFunction that does Foo\n\nx = package.funcFoo(u)\n[x, y] = package.funcFoo(u, t)\n\nTest for auto-linking with baseFunction() and BaseClass, etc."
     )
     assert (
         docstring1.rawsource

--- a/tests/test_autodoc_short_links.py
+++ b/tests/test_autodoc_short_links.py
@@ -1,0 +1,299 @@
+# -*- coding: utf-8 -*-
+"""
+    test_autodoc
+    ~~~~~~~~~~~~
+
+    Test the autodoc extension.
+
+    :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+import pickle
+import os
+import sys
+
+import pytest
+
+from sphinx import addnodes
+from sphinx.testing.fixtures import make_app, test_params  # noqa: F811;
+from sphinx.testing.path import path
+
+
+@pytest.fixture(scope="module")
+def rootdir():
+    return path(os.path.dirname(__file__)).abspath()
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_target(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_short_links": True}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_target.doctree").read_bytes())
+    property_section = content[0][2][1][2][0]  # a bit fragile, I know
+    method_section = content[0][2][1][2][1]  # a bit fragile, I know
+    assert len(content) == 1
+    assert (
+        content[0].astext()
+        == "target\n\n\n\nclass ClassExample(a)\n\nBases: handle\n\nExample class\n\nClassExample Properties:\n\na - first property of ClassExample\nb - second property of ClassExample\nc - third property of ClassExample\n\nClassExample Methods:\n\nClassExample - the constructor and a reference to mymethod()\nmymethod - a method in ClassExample\n\nSee also BaseClass, baseFunction, unknownEntity.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb\n\na property with default value\n\n\n\nc\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
+    )
+    assert (
+        property_section.rawsource
+        == "ClassExample Properties:\na - first property of ClassExample\nb - second property of ClassExample\nc - third property of ClassExample"
+    )
+    assert (
+        method_section.rawsource
+        == "ClassExample Methods:\nClassExample - the constructor and a reference to mymethod()\nmymethod - a method in ClassExample\n"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_target_show_default_value(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_short_links": True, "matlab_show_property_default_value": True}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_target.doctree").read_bytes())
+    property_section = content[0][2][1][2][0]  # a bit fragile, I know
+    method_section = content[0][2][1][2][1]  # a bit fragile, I know
+    assert len(content) == 1
+    assert (
+        content[0].astext()
+        == "target\n\n\n\nclass ClassExample(a)\n\nBases: handle\n\nExample class\n\nClassExample Properties:\n\na - first property of ClassExample\nb - second property of ClassExample\nc - third property of ClassExample\n\nClassExample Methods:\n\nClassExample - the constructor and a reference to mymethod()\nmymethod - a method in ClassExample\n\nSee also BaseClass, baseFunction, unknownEntity.\n\nProperty Summary\n\n\n\n\n\na\n\na property\n\n\n\nb = 10\n\na property with default value\n\n\n\nc = [10; ... 30]\n\na property with multiline default value\n\nMethod Summary\n\n\n\n\n\nmymethod(b)\n\nA method in ClassExample\n\nParameters\n\nb – an input to mymethod()"
+    )
+    assert (
+        property_section.rawsource
+        == "ClassExample Properties:\na - first property of ClassExample\nb - second property of ClassExample\nc - third property of ClassExample"
+    )
+    assert (
+        method_section.rawsource
+        == "ClassExample Methods:\nClassExample - the constructor and a reference to mymethod()\nmymethod - a method in ClassExample\n"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_target_auto_link_basic(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_short_links": True, "matlab_auto_link": "basic"}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_target.doctree").read_bytes())
+    property_section = content[0][2][1][2][0]  # a bit fragile, I know
+    method_section = content[0][2][1][2][1]  # a bit fragile, I know
+    see_also_line = content[0][2][1][3]  # a bit fragile, I know
+    assert len(content) == 1
+    assert (
+        property_section.rawsource
+        == "ClassExample Properties:\n* :attr:`a <ClassExample.a>` - first property of ClassExample\n* :attr:`b <ClassExample.b>` - second property of ClassExample\n* :attr:`c <ClassExample.c>` - third property of ClassExample"
+    )
+    assert (
+        method_section.rawsource
+        == "ClassExample Methods:\n* :meth:`ClassExample() <ClassExample.ClassExample>` - the constructor and a reference to mymethod()\n* :meth:`mymethod() <ClassExample.mymethod>` - a method in ClassExample\n"
+    )
+    assert (
+        see_also_line.rawsource
+        == "See also :class:`BaseClass`, :func:`baseFunction`, ``unknownEntity``."
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_target_auto_link_all(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_short_links": True, "matlab_auto_link": "all"}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_target.doctree").read_bytes())
+    property_section = content[0][2][1][2][0]  # a bit fragile, I know
+    method_section = content[0][2][1][2][1]  # a bit fragile, I know
+    see_also_line = content[0][2][1][3]  # a bit fragile, I know
+    assert len(content) == 1
+    assert (
+        property_section.rawsource
+        == "ClassExample Properties:\n* :attr:`a <ClassExample.a>` - first property of :class:`ClassExample`\n* :attr:`b <ClassExample.b>` - second property of :class:`ClassExample`\n* :attr:`c <ClassExample.c>` - third property of :class:`ClassExample`"
+    )
+    assert (
+        method_section.rawsource
+        == "ClassExample Methods:\n* :meth:`ClassExample() <ClassExample.ClassExample>` - the constructor and a reference to :meth:`mymethod() <ClassExample.mymethod>`\n* :meth:`mymethod() <ClassExample.mymethod>` - a method in :class:`ClassExample`\n"
+    )
+    assert (
+        see_also_line.rawsource
+        == "See also :class:`BaseClass`, :func:`baseFunction`, ``unknownEntity``."
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_classfolder(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_short_links": True}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_classfolder.doctree").read_bytes())
+    assert len(content) == 1
+    assert (
+        content[0].astext()
+        == "classfolder\n\n\n\nclass ClassFolder(p)\n\nA class in a folder\n\nProperty Summary\n\n\n\n\n\np\n\na property of a class folder\n\nMethod Summary\n\n\n\n\n\nmethod_inside_classdef(a, b)\n\nMethod inside class definition"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_package(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_short_links": True}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_package.doctree").read_bytes())
+    docstring1 = content[0][2][1][1]  # a bit fragile, I know
+    docstring2 = content[0][2][1][2][0][1][1][4][1][0]  # a bit fragile, I know
+    docstring3 = content[0][2][1][2][0][2][1][2][1][0]  # a bit fragile, I know
+    assert len(content) == 1
+    assert (
+        content[0].astext()
+        == "package\n\n\n\nclass package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars\n\nNumber of bars\n\n\n\nfoos\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\npackage.funcFoo(u, t)\n\nFunction that does Foo"
+    )
+    assert docstring1.rawsource == "The Bar and Foo handler, with a doFoo() method."
+    assert docstring2.rawsource == "Number of foos, used by doBar() method"
+    assert docstring3.rawsource == "Doing bar, not called by ClassBar()"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_package_show_default_value(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_short_links": True, "matlab_show_property_default_value": True}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_package.doctree").read_bytes())
+    assert len(content) == 1
+    assert (
+        content[0].astext()
+        == "package\n\n\n\nclass package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars = 'bars'\n\nNumber of bars\n\n\n\nfoos = 10\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\npackage.funcFoo(u, t)\n\nFunction that does Foo"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_package_auto_link_all(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_short_links": True, "matlab_auto_link": "all"}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_package.doctree").read_bytes())
+    docstring1 = content[0][2][1][1]  # a bit fragile, I know
+    docstring2 = content[0][2][1][2][0][1][1][4][1][0]  # a bit fragile, I know
+    docstring3 = content[0][2][1][2][0][2][1][2][1][0]  # a bit fragile, I know
+    assert len(content) == 1
+    assert (
+        content[0].astext()
+        == "package\n\n\n\nclass package.ClassBar\n\nBases: handle\n\nThe Bar and Foo handler, with a doFoo() method.\n\nConstructor Summary\n\n\n\n\n\nClassBar()\n\nInitialize the bars and foos\n\nProperty Summary\n\n\n\n\n\nbars\n\nNumber of bars\n\n\n\nfoos\n\nNumber of foos, used by doBar() method\n\nMethod Summary\n\n\n\n\n\ndoBar()\n\nDoing bar, not called by ClassBar()\n\n\n\ndoFoo()\n\nDoing foo\n\n\n\n\n\n\n\npackage.funcFoo(u, t)\n\nFunction that does Foo"
+    )
+    assert (
+        docstring1.rawsource
+        == "The Bar and Foo handler, with a :meth:`doFoo() <package.ClassBar.doFoo>` method."
+    )
+    assert (
+        docstring2.rawsource
+        == "Number of foos, used by :meth:`doBar() <package.ClassBar.doBar>` method"
+    )
+    assert (
+        docstring3.rawsource
+        == "Doing bar, not called by :meth:`ClassBar() <package.ClassBar.ClassBar>`"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_submodule(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_short_links": True}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_submodule.doctree").read_bytes())
+    bases_line = content[0][2][1][0]
+    assert len(content) == 1
+    assert (
+        content[0].astext()
+        == "submodule\n\n\n\nclass ClassMeow\n\nBases: package.ClassBar\n\nClass which inherits from a package\n\nMethod Summary\n\n\n\n\n\nsay()\n\nSay Meow\n\n\n\nfuncMeow(input)\n\nTests a function with comments after docstring"
+    )
+    assert bases_line.rawsource == "Bases: :class:`package.ClassBar <package.ClassBar>`"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_submodule_show_default_value(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_short_links": True, "matlab_show_property_default_value": True}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_submodule.doctree").read_bytes())
+    assert len(content) == 1
+    assert (
+        content[0].astext()
+        == "submodule\n\n\n\nclass ClassMeow\n\nBases: package.ClassBar\n\nClass which inherits from a package\n\nMethod Summary\n\n\n\n\n\nsay()\n\nSay Meow\n\n\n\nfuncMeow(input)\n\nTests a function with comments after docstring"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_root(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_short_links": True}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_root.doctree").read_bytes())
+    assert len(content) == 1
+    assert (
+        content[0].astext()
+        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nBaseClass Methods:\n\nBaseClass - the constructor, whose description extends\n\nto the next line\n\nDoBase - another BaseClass method\n\nSee Also\n\ntarget.ClassExample, baseFunction, ClassExample\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\ntarget.submodule.ClassMeow\ntarget.package.ClassBar\nClassMeow\npackage.ClassBar"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_root_show_default_value(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_short_links": True, "matlab_show_property_default_value": True}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_root.doctree").read_bytes())
+    assert len(content) == 1
+    assert (
+        content[0].astext()
+        == "root\n\n\n\nclass BaseClass(args)\n\nA class in the very root of the directory\n\nBaseClass Methods:\n\nBaseClass - the constructor, whose description extends\n\nto the next line\n\nDoBase - another BaseClass method\n\nSee Also\n\ntarget.ClassExample, baseFunction, ClassExample\n\nConstructor Summary\n\n\n\n\n\nBaseClass(args)\n\nThe constructor\n\nMethod Summary\n\n\n\n\n\nDoBase()\n\nDo the Base thing\n\n\n\nbaseFunction(x)\n\nReturn the base of x\n\nSee Also:\n\ntarget.submodule.ClassMeow\ntarget.package.ClassBar\nClassMeow\npackage.ClassBar"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_root_auto_link_basic(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_autodoc"
+    confdict = {"matlab_short_links": True, "matlab_auto_link": "basic"}
+    app = make_app(srcdir=srcdir, confoverrides=confdict)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_root.doctree").read_bytes())
+    method_section = content[0][2][1][1][0]  # a bit fragile, I know
+    see_also_line_1 = content[0][2][1][1][1]  # a bit fragile, I know
+    see_also_line_2 = content[0][4][1][1][0]  # a bit fragile, I know
+    assert len(content) == 1
+    assert (
+        method_section.rawsource
+        == "BaseClass Methods:\n* :meth:`BaseClass() <BaseClass.BaseClass>` - the constructor, whose description extends\n    to the next line\n* :meth:`DoBase() <BaseClass.DoBase>` - another BaseClass method\n"
+    )
+    assert (
+        see_also_line_1.rawsource
+        == "See Also\n:class:`target.ClassExample`, :func:`baseFunction`, :class:`ClassExample`\n\n"
+    )
+    assert (
+        see_also_line_2.rawsource
+        == "See Also:\n:class:`target.submodule.ClassMeow`\n:class:`target.package.ClassBar`\n:class:`ClassMeow`\n:class:`package.ClassBar`"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_autodoc_short_links.py
+++ b/tests/test_autodoc_short_links.py
@@ -221,7 +221,7 @@ def test_submodule(make_app, rootdir):
         content[0].astext()
         == "submodule\n\n\n\nclass ClassMeow\n\nBases: package.ClassBar\n\nClass which inherits from a package\n\nMethod Summary\n\n\n\n\n\nsay()\n\nSay Meow\n\n\n\nfuncMeow(input)\n\nTests a function with comments after docstring"
     )
-    assert bases_line.rawsource == "Bases: :class:`package.ClassBar <package.ClassBar>`"
+    assert bases_line.rawsource == "Bases: :class:`package.ClassBar`"
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")

--- a/tests/test_duplicated_link.py
+++ b/tests/test_duplicated_link.py
@@ -39,7 +39,7 @@ def test_with_prefix(make_app, rootdir):
     assert (
         section.astext()
         == "NiceFiniteGroup\n\n\n\nclass +replab.NiceFiniteGroup\n\nBases: "
-        "replab.FiniteGroup\n\nA nice finite group is a finite group equipped "
+        "+replab.FiniteGroup\n\nA nice finite group is a finite group equipped "
         "with an injective homomorphism into a permutation group\n\nReference that triggers the error: eqv"
     )
 

--- a/tests/test_package_links.py
+++ b/tests/test_package_links.py
@@ -37,7 +37,7 @@ def test_with_prefix(make_app, rootdir):
 
     assert (
         content[5].astext()
-        == "class +replab.Action\n\nBases: replab.Str\n\nAn action group …\n\nMethod Summary\n\n\n\n\n\nleftAction(g, p)\n\nReturns the left action"
+        == "class +replab.Action\n\nBases: +replab.Str\n\nAn action group …\n\nMethod Summary\n\n\n\n\n\nleftAction(g, p)\n\nReturns the left action"
     )
 
 


### PR DESCRIPTION
This is preliminary work to address #178.

As stated there, currently:
- Added a `matlab_auto_link` config option that currently takes 2 options, `"see_also"` and `"all"`.
- Added a `ref_role()` method to `MatObject` types to return the role to use for references to each type of object. 
- _(now fixed)_ Need to update the regex to match only whole words. Right now if you have `myClass` and `myClassFoo`, it will replace `myClassFoo` with ``:class:`myClass`Foo``, which isn't quite what we're looking for.

