### PR TITLE
Fix parsing of classes with trailing semicolon

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+sphinxcontrib-matlabdomain-0.19.1 (2023-05-17)
+==============================================
+
+* Fix parsing of classes with trailing ``;`` after ``end``
+
+
 sphinxcontrib-matlabdomain-0.19.0 (2023-05-16)
 ==============================================
 

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -16,11 +16,11 @@
                Marc-Henri Bleu-Laine and
                Nikolaas N. Oosterhof and
                ptitrex},
-  title     = {sphinx-contrib/matlabdomain: 0.19.0},
-  month     = mar,
+  title     = {sphinx-contrib/matlabdomain: 0.19.1},
+  month     = may,
   year      = 2023,
   publisher = {Zenodo},
-  version   = {0.19.0},
+  version   = {0.19.1},
   doi       = {10.5281/zenodo.7746009},
   url       = {https://github.com/sphinx-contrib/matlabdomain}
 }

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -1006,6 +1006,7 @@ class MatClass(MatMixin, MatObject):
                         idx += whitespace
                     else:
                         idx += 1
+
                 # =================================================================
                 # properties blocks
                 if self._tk_eq(idx, (Token.Keyword, "properties")):
@@ -1285,6 +1286,9 @@ class MatClass(MatMixin, MatObject):
                     # Token.Keyword: "end" terminates events block
                     while self._tk_ne(idx, (Token.Keyword, "end")):
                         idx += 1
+                    idx += 1
+                if self._tk_eq(idx, (Token.Punctuation, ";")):
+                    # Skip trailing semicolon after end.
                     idx += 1
         except IndexError:
             logger.warning(

--- a/tests/test_data/ClassWithTrailingSemicolons.m
+++ b/tests/test_data/ClassWithTrailingSemicolons.m
@@ -1,0 +1,40 @@
+classdef ClassWithTrailingSemicolons < hgsetget
+    % Smoothing like it is performed withing Cxx >v7.0 (until v8.2 at least).
+    % Uses constant 228p_12k frequency vector:
+    
+    properties
+        m_dSmoothingWidth;                               % Smoothing Width
+        m_nExtL;
+        m_nExtR;
+        m_dSigmaSquared;
+        m_dFreqExtended;
+        m_dFreqLeft;
+        m_dFreqRight;
+        m_dBandWidth;
+    end;
+    properties (Constant)
+        m_dFreq = [ 100  105  110  115  120  125  130  135  145  150 ...
+            160  165  175  180  190  200  210  220  230  240 ...
+            250  260  275  290  300  315  330  345  360  380 ...
+            400  420  440  460  480  500  525  550  575  600 ...
+            630  660  700  730  760  800  830  870  900  950 ...
+            1000 1050 1100 1150 1200 1250:62.5:12000];
+    end;
+    methods
+        function obj = ClassWithTrailingSemicolons()
+            % Assign smoothing width to object properties
+            obj.m_dSmoothingWidth = 10.0;
+        end;
+        function smooth_curve = CxxSmoothing(obj, curve)
+            smooth_curve = zeros(1, length(obj.m_dFreq));
+            
+        end;
+        function sigma = CalculateSigma(obj)
+            sigma = obj.m_dFreq;
+            for i = 1:length(sigma)
+                iSigma = sigma(i);
+                sigma(i) = iSigma * (obj.m_dSmoothingWidth / 100);
+            end;
+        end;
+    end;
+end

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -111,6 +111,7 @@ def test_module(mod):
         "ClassWithLongPropertyTrailingEmptyDocstrings",
         "ClassWithPropertyValidators",
         "ClassWithTrailingCommentAfterBases",
+        "ClassWithTrailingSemicolons",
     }
     assert all_items == expected_items
     assert mod.getter("__name__") in entities_table

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -805,5 +805,33 @@ def test_ClassWithEllipsisProperties():
 #         D = '...'; % String with line continuation
 
 
+def test_ClassWithTrailingSemicolons():
+    mfile = os.path.join(TESTDATA_ROOT, "ClassWithTrailingSemicolons.m")
+    obj = mat_types.MatObject.parse_mfile(
+        mfile, "ClassWithTrailingSemicolons", "test_data"
+    )
+    assert (
+        obj.docstring
+        == " Smoothing like it is performed withing Cxx >v7.0 (until v8.2 at least).\n Uses constant 228p_12k frequency vector:\n"
+    )
+    assert obj.bases == ["hgsetget"]
+    assert list(obj.methods.keys()) == [
+        "ClassWithTrailingSemicolons",
+        "CxxSmoothing",
+        "CalculateSigma",
+    ]
+    assert list(obj.properties.keys()) == [
+        "m_dSmoothingWidth",
+        "m_nExtL",
+        "m_nExtR",
+        "m_dSigmaSquared",
+        "m_dFreqExtended",
+        "m_dFreqLeft",
+        "m_dFreqRight",
+        "m_dBandWidth",
+        "m_dFreq",
+    ]
+
+
 if __name__ == "__main__":
     pytest.main([os.path.abspath(__file__)])


### PR DESCRIPTION
Found some code with trailing semicolons after end, i.e. 

```
classdef 
    properties
        ...
    end;

    methods
       ...
    end;
end;

```

This would result in a endless loop in `MatClass.__init__`.