### PR TITLE
Fixed issue with "exclude-members" in `MatClassDocumenter`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,19 @@
+sphinxcontrib-matlabdomain-0.20.0 (2023-MM-DD)
+==============================================
+
+* Fixed `Issue 188`_ and `Issue 189`_, which caused the extension to crash if
+  the documentation contained ``:exclude-members:``.
+* Added a new configuration: ``matlab_auto_links``. It will automatically
+  convert the names of known entities (e.g. classes, functions, properties,
+  methods) to links! This means that we can write class documentation as `MATLAB
+  Class Help`_ suggests. Including property and methods lists in the class
+  docstring.
+
+.. _Issue 188: https://github.com/sphinx-contrib/matlabdomain/issues/188
+.. _Issue 189: https://github.com/sphinx-contrib/matlabdomain/issues/189
+.. _MATLAB Class Help:  https://mathworks.com/help/matlab/matlab_prog/create-help-for-classes.html
+
+
 sphinxcontrib-matlabdomain-0.19.1 (2023-05-17)
 ==============================================
 

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -40,6 +40,8 @@ from sphinx.ext.autodoc import (
     ALL,
     INSTANCEATTR,
     members_option,
+    exclude_members_option,
+    EMPTY,
     SUPPRESS,
     annotation_option,
     bool_option,
@@ -242,7 +244,7 @@ class MatlabDocumenter(PyDocumenter):
                 nn = n.replace("+", "")  # remove + from name
                 pat = (
                     r"(?<!(`|\.|\+|<))\b"  # negative look-behind for ` or . or + or <
-                    + nn.replace(".", "\.")  # escape .
+                    + nn.replace(".", r"\.")  # escape .
                     + r"\b(?!(`|\sProperties|\sMethods):)"  # negative look-ahead for ` or " Properties:" or " Methods:"
                 )
                 p = re.compile(pat)
@@ -921,7 +923,7 @@ class MatClassDocumenter(MatModuleLevelDocumenter):
         "inherited-members": bool_option,
         "show-inheritance": bool_option,
         "member-order": identity,
-        "exclude-members": members_option,
+        "exclude-members": exclude_members_option,
         "special-members": members_option,
         "private-members": members_option,
         "protected-members": members_option,
@@ -1190,7 +1192,7 @@ class MatClassDocumenter(MatModuleLevelDocumenter):
         # save up original indent and exclude_members
         indent = self.indent
         if self.options.exclude_members:
-            exclude_members = self.options.exclude_members.copy()
+            exclude_members = self.options.exclude_members
         else:
             exclude_members = []
 
@@ -1198,7 +1200,10 @@ class MatClassDocumenter(MatModuleLevelDocumenter):
         self.add_line(heading, "<autodoc>")
         self.indent += "   "
         self.add_line(".. ", "<autodoc>")  # a comment, to force a <dd> in the HTML
-        self.options.exclude_members = exclude_members + new_excludes
+        if exclude_members is EMPTY:
+            self.options.exclude_members = set(new_excludes)
+        else:
+            self.options.exclude_members = set(list(exclude_members) + new_excludes)
         MatModuleLevelDocumenter.document_members(self, all_members)
 
         # restore original indent and exclude_members

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -1514,6 +1514,10 @@ class MatProperty(MatObject):
         return "attr"
 
     @property
+    def __module__(self):
+        return self.cls.module
+
+    @property
     def __doc__(self):
         return self.docstring
 

--- a/tests/roots/test_numad/Makefile
+++ b/tests/roots/test_numad/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SPHINXPROJ    = test_autodoc
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/tests/roots/test_numad/conf.py
+++ b/tests/roots/test_numad/conf.py
@@ -1,0 +1,10 @@
+import os
+
+matlab_src_dir = os.path.abspath(".")
+matlab_keep_package_prefix = False
+extensions = ["sphinx.ext.autodoc", "sphinxcontrib.matlab"]
+primary_domain = "mat"
+project = "test_class_options"
+master_doc = "index"
+source_suffix = ".rst"
+nitpicky = True

--- a/tests/roots/test_numad/index.rst
+++ b/tests/roots/test_numad/index.rst
@@ -1,0 +1,15 @@
+Description
+===========
+
+In this directory we test features used in the NUMAD project.
+
+Table of contents
+=================
+
+.. automodule:: target
+
+.. toctree::
+   :maxdepth: 2
+
+   index_first
+   index_second

--- a/tests/roots/test_numad/index_first.rst
+++ b/tests/roots/test_numad/index_first.rst
@@ -1,0 +1,10 @@
+First Class
+============
+
+.. autoclass:: target.FirstClass
+	:members:
+	:exclude-members:
+	:no-undoc-members:
+
+.. autoattribute:: target.FirstClass.a
+.. autoattribute:: target.FirstClass.b

--- a/tests/roots/test_numad/index_second.rst
+++ b/tests/roots/test_numad/index_second.rst
@@ -1,0 +1,7 @@
+Second Class
+============
+
+.. autoclass:: target.SecondClass
+	:members:
+	:undoc-members:
+	:exclude-members: second_method

--- a/tests/roots/test_numad/make.bat
+++ b/tests/roots/test_numad/make.bat
@@ -1,0 +1,36 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+set SPHINXPROJ=test_autodoc
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+
+:end
+popd

--- a/tests/roots/test_numad/readme.txt
+++ b/tests/roots/test_numad/readme.txt
@@ -1,0 +1,15 @@
+Test of class options
+---------------------
+
+Regular build.::
+
+    make html
+
+Regular build with very verbose settings, piped to file.::
+
+    sphinx-build -vvv -b html . _build\html > sphinx.log
+
+
+With "short links" enabled, note the output folder is changed to ``_build\short\html``.::
+
+    sphinx-build -D matlab_short_links=True -b html . _build\short\html

--- a/tests/roots/test_numad/target/FirstClass.m
+++ b/tests/roots/test_numad/target/FirstClass.m
@@ -1,0 +1,18 @@
+classdef FirstClass
+    % First class with two properties
+
+    properties
+        a % The a property
+        b % The b property
+    end
+
+    methods
+        function obj = ClassSimple(a)
+
+        end
+
+        function c = method(obj, b)
+            c = b * 2;
+        end
+    end
+end

--- a/tests/roots/test_numad/target/SecondClass.m
+++ b/tests/roots/test_numad/target/SecondClass.m
@@ -1,0 +1,23 @@
+classdef SecondClass
+    % Second class with methods and properties
+
+    properties
+        a % The a property
+        b % The b property
+    end
+
+    methods
+        function obj = SecondClass(a)
+            % The second class constructor
+
+        end
+
+        function c = first_method(obj, b)
+            c = b * 2;
+        end
+
+        function c = second_method(obj, b)
+            c = b * 2;
+        end
+    end
+end

--- a/tests/roots/test_numad/target/readme.txt
+++ b/tests/roots/test_numad/target/readme.txt
@@ -1,0 +1,6 @@
+Here we test an example found in the NuMAD documentation.
+
+* A `:autoclass:` directive with an empty `:exclude-members:` option.
+* A `:autoattribute:` directive.
+
+Both caused errors with version 0.19.0 and 0.19.1.

--- a/tests/test_numad.py
+++ b/tests/test_numad.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""
+    test_autodoc
+    ~~~~~~~~~~~~
+
+    Test the autodoc extension.
+
+    :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+import pickle
+import os
+import sys
+
+import pytest
+
+from sphinx import addnodes
+from sphinx.testing.fixtures import make_app, test_params  # noqa: F811;
+from sphinx.testing.path import path
+
+
+@pytest.fixture(scope="module")
+def rootdir():
+    return path(os.path.dirname(__file__)).abspath()
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_first(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_numad"
+    app = make_app(srcdir=srcdir)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_first.doctree").read_bytes())
+    assert (
+        content.astext()
+        == "First Class\n\n\n\nclass target.FirstClass\n\nFirst class with two properties\n\nProperty Summary\n\n\n\n\n\na\n\nThe a property\n\n\n\nb\n\nThe b property\n\n\n\nFirstClass.a\n\nThe a property\n\n\n\nFirstClass.b\n\nThe b property"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_second(make_app, rootdir):
+    srcdir = rootdir / "roots" / "test_numad"
+    app = make_app(srcdir=srcdir)
+    app.builder.build_all()
+
+    content = pickle.loads((app.doctreedir / "index_second.doctree").read_bytes())
+    assert (
+        content.astext()
+        == "Second Class\n\n\n\nclass target.SecondClass(a)\n\nSecond class with methods and properties\n\nConstructor Summary\n\n\n\n\n\nSecondClass(a)\n\nThe second class constructor\n\nProperty Summary\n\n\n\n\n\na\n\nThe a property\n\n\n\nb\n\nThe b property\n\nMethod Summary\n\n\n\n\n\nfirst_method(b)\n\n"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
If the `:exclude-members:` options was added to a `autoclass` directive Sphinx would stop because of an exception thrown in `MatClassDocumenter:document_member_section`.

This is fixed now, as well as using the correct type the option, `sphinx.ext.autodoc.exclude_members_option`.

Fixed another issue in `MatProperty` that could not return the module it belongs to.

Added more tests, `tests/roots/test_numad`
