### PR TITLE
Move item to correct location

### DIFF
--- a/tests/test_docs/conf.py
+++ b/tests/test_docs/conf.py
@@ -9,6 +9,7 @@ author = "Mark Mikofski, Jørgen Cederberg"
 
 sys.path.insert(0, os.path.abspath(os.path.join("..", "..")))
 matlab_src_dir = os.path.abspath("..")
+matlab_show_property_default_value = True
 
 extensions = ["sphinx.ext.autodoc", "sphinxcontrib.matlab"]
 primary_domain = "mat"

--- a/tests/test_docs/index.rst
+++ b/tests/test_docs/index.rst
@@ -273,6 +273,15 @@ A MATLAB class with strings using single and double quotes.
 .. autoclass:: ClassWithStrings
     :members:
 
+
+Class with string ellipsis
+++++++++++++++++++++++++++
+A class that tests the lexer.
+
+.. autoclass:: ClassWithStringEllipsis
+    :members:
+
+
 ClassWithDummyArguments
 +++++++++++++++++++++++
 
@@ -412,12 +421,6 @@ A Matlab unittest class
     :members:
     :show-inheritance:
 
-Class with string ellipsis
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-A class that tests the lexer.
-
-.. autoclass:: ClassWithStringEllipsis
-    :members:
 
 
 


### PR DESCRIPTION
The `ClassWithStringEllipsis` could not be found, as it was in the incorrect "module".

Enabled `matlab_show_property_default_value`.