### PR TITLE
fix autolink error that occurs when "See Also" line is succeeded by "--------"

### DIFF
--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -452,9 +452,9 @@ class MatObject(object):
         # codeText = codeDesc.text
 
         doc = []
-        if coreDesc is not None:
+        if coreDesc is not None and coreDesc.text is not None:
             doc.append(coreDesc.text)
-        if metaDesc is not None:
+        if metaDesc is not None and metaDesc.text is not None:
             doc.append(metaDesc.text)
         docstring = "\n\n".join(doc)
 


### PR DESCRIPTION
This usually happens when using numpy syntax docstrings, i.e.

```
    % See Also
    % --------
    % some text here
```


The errors looks like this:

```
File "/home/luis/.local/lib/python3.10/site-packages/sphinxcontrib/mat_documenters.py", line 206, in auto_link_see_also
    entries_str = match.group(2)  # the entries
AttributeError: 'NoneType' object has no attribute 'group'
```

The fix looks like this (line 206 is new):

https://github.com/sphinx-contrib/matlabdomain/blob/f52ccbaa3e22117ebb9f4975624357db5fb37acf/sphinxcontrib/mat_documenters.py#L206-L207