### PR TITLE
Add support for function with outputs but no inputs

### DIFF
--- a/sphinxcontrib/mat_lexer.py
+++ b/sphinxcontrib/mat_lexer.py
@@ -342,12 +342,7 @@ class MatlabLexer(RegexLexer):
             (
                 r"(\s*)(?:(.+)(\s*)(=)(\s*))?([a-zA-Z_]\w*)",
                 bygroups(
-                    Whitespace,
-                    Text,
-                    Whitespace,
-                    Punctuation,
-                    Whitespace,
-                    Name.Function
+                    Whitespace, Text, Whitespace, Punctuation, Whitespace, Name.Function
                 ),
                 "#pop",
             ),

--- a/sphinxcontrib/mat_lexer.py
+++ b/sphinxcontrib/mat_lexer.py
@@ -338,7 +338,7 @@ class MatlabLexer(RegexLexer):
                 ),
                 "#pop",
             ),
-            # function with with outputs but no inputs
+            # function with outputs but no inputs
             (
                 r"(\s*)(?:(.+)(\s*)(=)(\s*))?([a-zA-Z_]\w*)",
                 bygroups(

--- a/sphinxcontrib/mat_lexer.py
+++ b/sphinxcontrib/mat_lexer.py
@@ -338,7 +338,20 @@ class MatlabLexer(RegexLexer):
                 ),
                 "#pop",
             ),
-            # function with no args
+            # function with with outputs but no inputs
+            (
+                r"(\s*)(?:(.+)(\s*)(=)(\s*))?([a-zA-Z_]\w*)",
+                bygroups(
+                    Whitespace,
+                    Text,
+                    Whitespace,
+                    Punctuation,
+                    Whitespace,
+                    Name.Function
+                ),
+                "#pop",
+            ),
+            # function with no inputs or outputs
             (r"(\s*)([a-zA-Z_]\w*)", bygroups(Text, Name.Function), "#pop"),
         ],
     }

--- a/tests/test_data/f_no_input_no_parentheses_no_docstring.m
+++ b/tests/test_data/f_no_input_no_parentheses_no_docstring.m
@@ -1,0 +1,2 @@
+function result = f_no_input_no_parentheses_no_docstring
+result = 1

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -68,6 +68,7 @@ def test_module(mod):
         "Bool",
         "ClassWithEvent",
         "f_no_input_no_output_no_parentheses",
+        "f_no_input_no_parentheses_no_docstring",
         "ClassWithCommentHeader",
         "f_with_comment_header",
         "f_with_dummy_argument",

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -211,12 +211,14 @@ def test_no_input_no_output_no_parentheses():
 
 
 def test_no_input_no_parentheses_no_docstring():
-    mfile = os.path.join(DIRNAME, "test_data", "f_no_input_no_parentheses_no_docstring.m")
+    mfile = os.path.join(
+        DIRNAME, "test_data", "f_no_input_no_parentheses_no_docstring.m"
+    )
     obj = mat_types.MatObject.parse_mfile(
         mfile, "f_no_input_no_parentheses_no_docstring", "test_data"
     )
     assert obj.name == "f_no_input_no_parentheses_no_docstring"
-    assert obj.retv == ['result']
+    assert obj.retv == ["result"]
     assert obj.args is None
 
 

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -210,6 +210,16 @@ def test_no_input_no_output_no_parentheses():
     )
 
 
+def test_no_input_no_parentheses_no_docstring():
+    mfile = os.path.join(DIRNAME, "test_data", "f_no_input_no_parentheses_no_docstring.m")
+    obj = mat_types.MatObject.parse_mfile(
+        mfile, "f_no_input_no_parentheses_no_docstring", "test_data"
+    )
+    assert obj.name == "f_no_input_no_parentheses_no_docstring"
+    assert obj.retv == ['result']
+    assert obj.args is None
+
+
 def test_ClassWithCommentHeader():
     mfile = os.path.join(DIRNAME, "test_data", "ClassWithCommentHeader.m")
     obj = mat_types.MatObject.parse_mfile(mfile, "ClassWithCommentHeader", "test_data")


### PR DESCRIPTION
This commit adds a specific lexer for a function with outputs but no inputs (or parentheses).

Fixes #199
