### PR TITLE
Fixed #214 - private subfolders incorrectly treated as class folder.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+sphinxcontrib-matlabdomain-0.20.1 (2023-09-14)
+==============================================
+
+* Fixed `Issue 214`_. After fixing `Issue 56`_, we introduced a bug parsing
+  ``private`` folders incorrectly.
+
+
 sphinxcontrib-matlabdomain-0.20.0 (2023-09-13)
 ==============================================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ sphinxcontrib-matlabdomain-0.20.1 (2023-09-14)
 * Fixed `Issue 214`_. After fixing `Issue 56`_, we introduced a bug parsing
   ``private`` folders incorrectly.
 
+.. _Issue 214: https://github.com/sphinx-contrib/matlabdomain/issues/214
+
 
 sphinxcontrib-matlabdomain-0.20.0 (2023-09-13)
 ==============================================

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -16,11 +16,11 @@
                Marc-Henri Bleu-Laine and
                Nikolaas N. Oosterhof and
                ptitrex},
-  title     = {sphinx-contrib/matlabdomain: 0.19.1},
-  month     = may,
+  title     = {sphinx-contrib/matlabdomain: 0.20.1},
+  month     = sep,
   year      = 2023,
   publisher = {Zenodo},
-  version   = {0.19.1},
+  version   = {0.20.1},
   doi       = {10.5281/zenodo.7746009},
   url       = {https://github.com/sphinx-contrib/matlabdomain}
 }

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -235,8 +235,18 @@ def analyze(app):
     # To
     #
     # ClassFolder (Class) with the method1 and method2 add to the ClassFolder Class.
+
+    def isClassFolderModule(name, entity):
+        if not isinstance(entity, MatModule):
+            return False
+
+        parts = name.split(".")
+        if "@" in name and parts[-1] != "private":
+            return True
+        return False
+
     class_folder_modules = {
-        k: v for k, v in entities_table.items() if "@" in k and isinstance(v, MatModule)
+        k: v for k, v in entities_table.items() if isClassFolderModule(k, v)
     }
     # For each Class Folder module
     for cf_name, cf_entity in class_folder_modules.items():

--- a/tests/roots/test_classfolder/@First/private/method_in_folder.m
+++ b/tests/roots/test_classfolder/@First/private/method_in_folder.m
@@ -1,0 +1,3 @@
+function [varargout] = method_in_private(obj, varargin)
+% A method defined in the private folder
+varargout = varargin;


### PR DESCRIPTION
We now correctly filter out `private` folders from a class folder definitions.
