### PR TITLE
Interpret `matlab_src_dir` relative to the sphinx source directory.

### DIFF
--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -201,7 +201,8 @@ def analyze(app):
     # `matlab_src_dir` is recursively scanned for MATLAB objects only once.
     # All entities found are stored in globally available `entities_table`
 
-    basedir = app.env.config.matlab_src_dir
+    # Interpret `matlab_src_dir` relative to the sphinx source directory.
+    basedir = os.path.normpath(os.path.join(app.env.srcdir, app.env.config.matlab_src_dir))
     MatObject.basedir = basedir  # set MatObject base directory
     MatObject.sphinx_env = app.env  # pass env to MatObject cls
     MatObject.sphinx_app = app  # pass app to MatObject cls


### PR DESCRIPTION
Instead of having an absolute path for `matlab_src_dir` in `conf.py` interpret the supplied value as path relative to the sphinx _source_ directory. This enables the use of _matlabdomain_ with, e.g., [sphinx-multiversion](https://github.com/Holzhaus/sphinx-multiversion) which relies on running sphinx-build on different versions checked out to temporary folders. Thanks to `os.path.join()` it is still possible to provide an absolute path, though.

This solves https://github.com/Holzhaus/sphinx-multiversion/issues/108 which I found while looking for a solution.