### PR TITLE
Fix parsing of property docstring.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,13 @@
 sphinxcontrib-matlabdomain-0.X.Y (2023-MM-DD)
 ==============================================
 
-* Fixed `Issue 225`. Empty ``@classfolder`` would throw an assertion error.
+* Fixed `Issue 220`. Parsing of property docstring could throw warning if there
+  were blank lines between comments.
 * Fixed `Issue 221`. Using builtin's in class folder defintion for methods
   defined in other files, threw a parsing warning.
+* Fixed `Issue 225`. Empty ``@classfolder`` would throw an assertion error.
 
+.. _Issue 220: https://github.com/sphinx-contrib/matlabdomain/issues/220
 .. _Issue 221: https://github.com/sphinx-contrib/matlabdomain/issues/221
 .. _Issue 225: https://github.com/sphinx-contrib/matlabdomain/issues/225
 

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -1220,6 +1220,10 @@ class MatClass(MatMixin, MatObject):
                                 docstring += "\n"
                                 self.properties[prop_name]["docstring"] = docstring
                                 idx += 1
+                        elif self.tokens[idx][0] is Token.Comment:
+                            # Comments seperated with blank lines.
+                            idx = idx - 1
+                            continue
                         else:
                             logger.warning(
                                 "sphinxcontrib-matlabdomain] Expected property in %s.%s - got %s",

--- a/tests/test_data/ClassWithSeperatedComments.m
+++ b/tests/test_data/ClassWithSeperatedComments.m
@@ -1,0 +1,8 @@
+classdef ClassWithSeperatedComments
+    properties
+        % some comment
+
+        % Another comment
+        prop
+    end
+end

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -115,6 +115,7 @@ def test_module(mod):
         "ClassWithPropertyValidators",
         "ClassWithTrailingCommentAfterBases",
         "ClassWithTrailingSemicolons",
+        "ClassWithSeperatedComments",
     }
     assert all_items == expected_items
     assert mod.getter("__name__") in entities_table

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -845,5 +845,17 @@ def test_ClassWithTrailingSemicolons():
     ]
 
 
+def test_ClassWithSeperatedComments():
+    mfile = os.path.join(TESTDATA_ROOT, "ClassWithSeperatedComments.m")
+    obj = mat_types.MatObject.parse_mfile(
+        mfile, "ClassWithSeperatedComments", "test_data"
+    )
+    assert obj.name == "ClassWithSeperatedComments"
+    assert obj.bases == []
+    assert "prop" in obj.properties
+    prop = obj.properties["prop"]
+    assert prop["docstring"] == " Another comment\n"
+
+
 if __name__ == "__main__":
     pytest.main([os.path.abspath(__file__)])


### PR DESCRIPTION
In a situation with a comment separated by blank lines before a new comment. The parser could throw a warning.

This closes #220.