### PR TITLE
Meta: Add trove classifier : `Framework :: Sphinx :: Domain`

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -16,11 +16,11 @@
                Marc-Henri Bleu-Laine and
                Nikolaas N. Oosterhof and
                ptitrex},
-  title     = {sphinx-contrib/matlabdomain: 0.21.0},
+  title     = {sphinx-contrib/matlabdomain: 0.21.1},
   month     = dec,
   year      = 2023,
   publisher = {Zenodo},
-  version   = {0.21.0},
+  version   = {0.21.1},
   doi       = {10.5281/zenodo.7746009},
   url       = {https://github.com/sphinx-contrib/matlabdomain}
 }

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "Topic :: Documentation",
         "Topic :: Utilities",
         "Framework :: Sphinx :: Extension",
+        "Framework :: Sphinx :: Domain",
     ],
     platforms="any",
     packages=find_packages(),


### PR DESCRIPTION
As discussed in https://github.com/sphinx-doc/sphinx/issues/11562, a new trove classifier for Sphinx domains has been added.