### PR TITLE
Hot-fix for `matlab_src_dir` relative path.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+sphinxcontrib-matlabdomain-0.21.2 (2023-12-17)
+==============================================
+
+* Interpret ``matlab_src_dir`` relative to the Sphinx source directory to be
+  compatible with `sphinx-multiversion`_.
+
+.. _sphinx-multiversion: https://pypi.org/project/sphinx-multiversion/
+
+
 sphinxcontrib-matlabdomain-0.21.1 (2023-12-16)
 ==============================================
 

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Additional Configuration
 ``matlab_src_dir``
    In order for the Sphinx MATLAB domain to auto-document MATLAB source code,
    set the config value of ``matlab_src_dir`` to an absolute path or a path
-   relative to the ``conf.py`` file. Currently only one MATLAB path can be
+   relative to the source directory. Currently only one MATLAB path can be
    specified, but that folder and all the subfolders in that tree will be
    searched.
 

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -214,8 +214,10 @@ def analyze(app):
         )
         return
 
-    # Interpret `matlab_src_dir` relative to the `conf.py` file.
-    basedir = os.path.normpath(os.path.join(app.confdir, app.env.config.matlab_src_dir))
+    # Interpret `matlab_src_dir` relative to the sphinx source directory.
+    basedir = os.path.normpath(
+        os.path.join(app.env.srcdir, app.env.config.matlab_src_dir)
+    )
     MatObject.basedir = basedir  # set MatObject base directory
     MatObject.sphinx_env = app.env  # pass env to MatObject cls
     MatObject.sphinx_app = app  # pass app to MatObject cls


### PR DESCRIPTION
As mentioned in https://github.com/sphinx-contrib/matlabdomain/pull/224#issuecomment-1858919457 it should be relative to the source directory to be compatible with https://pypi.org/project/sphinx-multiversion/