### PR TITLE
Fixed issue with incorrect warning on class names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+sphinxcontrib-matlabdomain-0.21.X (2024-MM-DD)
+==============================================
+
+* Fixed issue with warning if there is a mismatch between filename and
+  classname, if the classname is a reserved word (like arguments).
+
+
 sphinxcontrib-matlabdomain-0.21.3 (2024-01-02)
 ==============================================
 

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -1055,10 +1055,10 @@ class MatClass(MatMixin, MatObject):
 
             # class "attributes"
             self.attrs, idx = self.attributes(idx, MATLAB_CLASS_ATTRIBUTE_TYPES)
-            # =====================================================================
-            # classname
-            idx += self._blanks(idx)  # skip blanks
-            if self._tk_ne(idx, (Token.Name, self.name)):
+
+            # Check if self.name matches the name in the file.
+            idx += self._blanks(idx)
+            if not self.tokens[idx][1] == self.name:
                 logger.warning(
                     "[sphinxcontrib-matlabdomain] Unexpected class name: '%s'."
                     " Expected '%s' in '%s'.",

--- a/tests/test_data/arguments.m
+++ b/tests/test_data/arguments.m
@@ -1,0 +1,26 @@
+classdef arguments < handle & matlab.mixin.Copyable
+   %ARGUMENTS Aggregate arguments for later
+
+   properties (SetAccess=private, GetAccess=public)
+      value
+   end
+
+   methods
+      function obj = arguments()
+         % Constructor for arguments
+         obj.value = {};
+      end
+      function add(obj, foo)
+         % Add new argument
+         if isa(foo, 'arguments')
+            for i = 1:length(foo.value)
+               obj.value{end+1} = foo.value{i};
+            end
+         else
+            obj.value{end+1} = foo;
+         end
+      end
+
+   end
+
+end

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -117,6 +117,7 @@ def test_module(mod):
         "ClassWithTrailingSemicolons",
         "ClassWithSeperatedComments",
         "ClassWithKeywordsAsFieldnames",
+        "arguments",
     }
     assert all_items == expected_items
     assert mod.getter("__name__") in entities_table

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -872,5 +872,17 @@ def test_ClassWithKeywordsAsFieldnames():
     assert meth.docstring == " Returns the value of `d`\n"
 
 
+def test_ClassWithNamedAsArguments():
+    mfile = os.path.join(TESTDATA_ROOT, "arguments.m")
+    obj = mat_types.MatObject.parse_mfile(mfile, "arguments", "test_data")
+    assert obj.name == "arguments"
+    assert obj.bases == ["handle", "matlab.mixin.Copyable"]
+    assert "value" in obj.properties
+    meth = obj.methods["arguments"]
+    assert meth.docstring == " Constructor for arguments\n"
+    meth = obj.methods["add"]
+    assert meth.docstring == " Add new argument\n"
+
+
 if __name__ == "__main__":
     pytest.main([os.path.abspath(__file__)])


### PR DESCRIPTION
For classes named with a reserved word (like arguments), we would print an incorrect warning.