### PR TITLE
GH Actions: Add separate job for Sphinx 4.5 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,8 +30,8 @@ jobs:
     - name: Run with Tox
       run: |
         pip install tox==4.8.0
-        pip install sphinxcontrib-applehelp==1.0.7
         pip install sphinxcontrib-devhelp==1.0.5
+        pip install sphinxcontrib-applehelp==1.0.7
         tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}-pygments${{matrix.pygments-version}}"
 
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    name: Run tests for Python ${{ matrix.python-version }}, Sphinx ${{ matrix.sphinx-version }},  Pygments ${{ matrix.pygments-version }}
+    name: Run tests for Python ${{ matrix.python-version }}, Sphinx ${{ matrix.sphinx-version }},  Pygments ${{ matrix.pygments-version }}, Applehelp ${{ matrix.applehelp-version}}
     timeout-minutes: 5
     runs-on: ubuntu-latest
     strategy:
@@ -20,6 +20,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         sphinx-version: ["45", "53", "60", "latest"]
         pygments-version: ["213", "latest"]
+        applehelp-version: ["107", "latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -30,7 +31,7 @@ jobs:
     - name: Run with Tox
       run: |
         pip install tox==4.8.0
-        tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}-pygments${{matrix.pygments-version}}"
+        tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}-pygments${{matrix.pygments-version}}-pygments${{matrix.pygments-version}}-applehelp${{matrix.applehelp-version}}"
 
   check:
     name: Run static analysis

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,14 +11,38 @@ on:
     - cron:  '* 6 * * *'
 
 jobs:
-  test:
-    name: Run tests for Python ${{ matrix.python-version }}, Sphinx ${{ matrix.sphinx-version }},  Pygments ${{ matrix.pygments-version }}, Applehelp ${{ matrix.applehelp-version}}
+  test-sphinx-45:
+    name: Run tests for Python ${{ matrix.python-version }}, Sphinx 4.5, Pygments ${{ matrix.pygments-version }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        sphinx-version: ["45", "53", "60", "latest"]
+        sphinx-version: ["45"]
+        pygments-version: ["213", "latest"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+    - name: Run with Tox
+      run: |
+        pip install tox==4.8.0
+        pip install sphinxcontrib-applehelp==1.0.7
+        pip install sphinxcontrib-applehelp==1.0.5
+        tox -e "${{matrix.python-version}}-sphinx${{sphinx.pygments-version}}-pygments${{matrix.pygments-version}}-pygments${{matrix.pygments-version}}
+
+
+  test-sphinx-newer:
+    name: Run tests for Python ${{ matrix.python-version }}, Sphinx ${{ matrix.sphinx-version }},  Pygments ${{ matrix.pygments-version }}
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        sphinx-version: ["53", "60", "latest"]
         pygments-version: ["213", "latest"]
         applehelp-version: ["107", "latest"]
     steps:
@@ -31,7 +55,7 @@ jobs:
     - name: Run with Tox
       run: |
         pip install tox==4.8.0
-        tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}-pygments${{matrix.pygments-version}}-pygments${{matrix.pygments-version}}-applehelp${{matrix.applehelp-version}}"
+        tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}-pygments${{matrix.pygments-version}}-pygments${{matrix.pygments-version}}"
 
   check:
     name: Run static analysis

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,8 +31,8 @@ jobs:
       run: |
         pip install tox==4.8.0
         pip install sphinxcontrib-applehelp==1.0.7
-        pip install sphinxcontrib-applehelp==1.0.5
-        tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}-pygments${{matrix.pygments-version}}
+        pip install sphinxcontrib-devhelp==1.0.5
+        tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}-pygments${{matrix.pygments-version}}"
 
 
   test-sphinx-newer:
@@ -44,7 +44,6 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         sphinx-version: ["53", "60", "latest"]
         pygments-version: ["213", "latest"]
-        applehelp-version: ["107", "latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,13 +12,12 @@ on:
 
 jobs:
   test-sphinx-45:
-    name: Run tests for Python ${{ matrix.python-version }}, Sphinx ${{ matrix.sphinx-version }}, Pygments ${{ matrix.pygments-version }}
+    name: Run tests for Python ${{ matrix.python-version }}, Sphinx 4.5, Pygments ${{ matrix.pygments-version }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        sphinx-version: ["45"]
+        python-version: ["3.8", "3.9"]
         pygments-version: ["213", "latest"]
     steps:
     - uses: actions/checkout@v3
@@ -30,9 +29,9 @@ jobs:
     - name: Run with Tox
       run: |
         pip install tox==4.8.0
-        pip install sphinxcontrib-devhelp==1.0.5
-        pip install sphinxcontrib-applehelp==1.0.7
-        tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}-pygments${{matrix.pygments-version}}"
+        pip install sphinxcontrib-devhelp==1.0.2
+        pip install sphinxcontrib-applehelp==1.0.4
+        tox -e "${{matrix.python-version}}-sphinx45-pygments${{matrix.pygments-version}}"
 
 
   test-sphinx-newer:
@@ -41,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         sphinx-version: ["53", "60", "latest"]
         pygments-version: ["213", "latest"]
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test-sphinx-45:
-    name: Run tests for Python ${{ matrix.python-version }}, Sphinx 4.5, Pygments ${{ matrix.pygments-version }}
+    name: Run tests for Python ${{ matrix.python-version }}, Sphinx ${{ matrix.sphinx-version }}, Pygments ${{ matrix.pygments-version }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
     strategy:
@@ -32,7 +32,7 @@ jobs:
         pip install tox==4.8.0
         pip install sphinxcontrib-applehelp==1.0.7
         pip install sphinxcontrib-applehelp==1.0.5
-        tox -e "${{matrix.python-version}}-sphinx${{sphinx.pygments-version}}-pygments${{matrix.pygments-version}}-pygments${{matrix.pygments-version}}
+        tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}-pygments${{matrix.pygments-version}}
 
 
   test-sphinx-newer:
@@ -55,7 +55,7 @@ jobs:
     - name: Run with Tox
       run: |
         pip install tox==4.8.0
-        tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}-pygments${{matrix.pygments-version}}-pygments${{matrix.pygments-version}}"
+        tox -e "${{matrix.python-version}}-sphinx${{matrix.sphinx-version}}-pygments${{matrix.pygments-version}}"
 
   check:
     name: Run static analysis

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,8 +29,6 @@ jobs:
     - name: Run with Tox
       run: |
         pip install tox==4.8.0
-        pip install sphinxcontrib-devhelp==1.0.2
-        pip install sphinxcontrib-applehelp==1.0.4
         tox -e "${{matrix.python-version}}-sphinx45-pygments${{matrix.pygments-version}}"
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     sphinx45: Sphinx>=4.5,<4.6
     sphinx45: sphinxcontrib-devhelp==1.0.2
     sphinx45: sphinxcontrib-applehelp==1.0.4
+    sphinx45: sphinxcontrib-htmlhelp==2.0.1
     sphinx53: Sphinx>=5.3,<5.4
     sphinx60: Sphinx>=6.0,<6.1
     sphinxlatest: Sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     sphinx45: sphinxcontrib-devhelp==1.0.2
     sphinx45: sphinxcontrib-applehelp==1.0.4
     sphinx45: sphinxcontrib-htmlhelp==2.0.1
+    sphinx45: serializinghtml==1.1.5
     sphinx53: Sphinx>=5.3,<5.4
     sphinx60: Sphinx>=6.0,<6.1
     sphinxlatest: Sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311}-sphinx{45,53,60,latest}-pygments{213,latest}-sphinxcontribapplehelp{107,latest}
+envlist = py{38,39,310,311}-sphinx{45,53,60,latest}-pygments{213,latest}-applehelp{107,latest}
 
 
 [testenv]
@@ -13,8 +13,8 @@ deps =
     sphinxdev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
     pygments213: Pygments>=2.0.1,<2.14.0
     pygmentlatest: Pygments
-    sphinxcontribapplehelp107: sphinxcontrib-applehelp<1.0.8
-    sphinxcontribapplehelplatest: sphinxcontrib-applehelp
+    applehelp107: sphinxcontrib-applehelp<1.0.8
+    applehelplatest: sphinxcontrib-applehelp
 commands =
     pytest -vv {posargs} tests/
     sphinx-build -b html -d {envtmpdir}/doctrees tests/test_docs {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ deps =
     .
     pytest
     sphinx45: Sphinx>=4.5,<4.6
+    sphinx45: sphinxcontrib-devhelp==1.0.2
+    sphinx45: sphinxcontrib-applehelp==1.0.4
     sphinx53: Sphinx>=5.3,<5.4
     sphinx60: Sphinx>=6.0,<6.1
     sphinxlatest: Sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,20 @@
 [tox]
-envlist = py{38,39,310,311}-sphinx{45,53,60,latest}-pygments{213,latest}
+envlist = py{38,39,310,311}-sphinx{45,53,60,latest}-pygments{213,latest}-sphinxcontribapplehelp{107,latest}
 
 
 [testenv]
 deps =
     .
     pytest
-    sphinx45: Sphinx>=4.5,<4.6 sphinxcontrib-applehelp<1.0.8
+    sphinx45: Sphinx>=4.5,<4.6
     sphinx53: Sphinx>=5.3,<5.4
     sphinx60: Sphinx>=6.0,<6.1
     sphinxlatest: Sphinx
     sphinxdev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
     pygments213: Pygments>=2.0.1,<2.14.0
     pygmentlatest: Pygments
+    sphinxcontribapplehelp107: sphinxcontrib-applehelp<1.0.8
+    sphinxcontribapplehelplatest: sphinxcontrib-applehelp
 commands =
     pytest -vv {posargs} tests/
     sphinx-build -b html -d {envtmpdir}/doctrees tests/test_docs {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     sphinx45: sphinxcontrib-devhelp==1.0.2
     sphinx45: sphinxcontrib-applehelp==1.0.4
     sphinx45: sphinxcontrib-htmlhelp==2.0.1
-    sphinx45: serializinghtml==1.1.5
+    sphinx45: sphinxcontrib-serializinghtml==1.1.5
     sphinx53: Sphinx>=5.3,<5.4
     sphinx60: Sphinx>=6.0,<6.1
     sphinxlatest: Sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     sphinx45: sphinxcontrib-applehelp==1.0.4
     sphinx45: sphinxcontrib-htmlhelp==2.0.1
     sphinx45: sphinxcontrib-serializinghtml==1.1.5
+    sphinx45: sphinxcontrib-qthelp==1.0.3
     sphinx53: Sphinx>=5.3,<5.4
     sphinx60: Sphinx>=6.0,<6.1
     sphinxlatest: Sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311}-sphinx{45,53,60,latest}-pygments{213,latest}-applehelp{107,latest}
+envlist = py{38,39,310,311}-sphinx{45,53,60,latest}-pygments{213,latest}
 
 
 [testenv]
@@ -13,8 +13,6 @@ deps =
     sphinxdev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
     pygments213: Pygments>=2.0.1,<2.14.0
     pygmentlatest: Pygments
-    applehelp107: sphinxcontrib-applehelp<1.0.8
-    applehelplatest: sphinxcontrib-applehelp
 commands =
     pytest -vv {posargs} tests/
     sphinx-build -b html -d {envtmpdir}/doctrees tests/test_docs {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = py{38,39,310,311}-sphinx{45,53,60,latest}-pygments{213,latest}
 deps =
     .
     pytest
-    sphinx45: Sphinx>=4.5,<4.6
+    sphinx45: Sphinx>=4.5,<4.6 sphinxcontrib-applehelp<1.0.8
     sphinx53: Sphinx>=5.3,<5.4
     sphinx60: Sphinx>=6.0,<6.1
     sphinxlatest: Sphinx


### PR DESCRIPTION
External sphinxcontrib packages, have been updated to require Sphinx>=5.0
- sphinxcontrib-devhelp==1.0.2
- sphinxcontrib-applehelp==1.0.4
- sphinxcontrib-htmlhelp==2.0.1
- sphinxcontrib-serializinghtml==1.1.5
- sphinxcontrib-qthelp==1.0.3

We therefore extracted testing on Sphinx 4.5 to use the explicit versions above,
and then only test on Python 3.8 and 3.9.

Further, testing on Sphinx>=5.3 now tests on Python 3.9, 3.10, 3.11 and 3.12.