### PR TITLE
Fix "can't link function short name if it matches module name"

### DIFF
--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -235,7 +235,10 @@ class MatlabDocumenter(PyDocumenter):
                             o = None
                         if o:
                             if isinstance(o, dict):
-                                o = o["class"]
+                                if "class" in o:
+                                    o = o["class"]
+                                elif "func" in o:
+                                    o = o["func"]
                             role = o.ref_role()
                             if role in ["class", "func"]:
                                 entries[k] = f":{role}:`{entries[k]}`"
@@ -318,7 +321,10 @@ class MatlabDocumenter(PyDocumenter):
         # auto-link known classes and functions everywhere
         for n, o in entities_table.items():
             if isinstance(o, dict):
-                o = o["class"]
+                if "class" in o:
+                    o = o["class"]
+                elif "func" in o:
+                    o = o["func"]
             role = o.ref_role()
             if role in ["class", "func"]:
                 nn = n.replace("+", "")  # remove + from name

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -296,7 +296,13 @@ def analyze(app):
     long_names = entities_table.keys()
     for name, entity in entities_table.items():
         short_name = shortest_name(name)
-        if short_name != name and not (short_name in long_names and name in long_names):
+        if (
+            short_name != name
+            and not (short_name in long_names and name in long_names)
+            or short_name in long_names
+            and (entity.ref_role() == "func" or entity.ref_role() == "class")
+            and entities_table[short_name].ref_role() == "mod"
+        ):
             # Only handle the below special case when overwriting entries in entities_table will not
             # introduce conflicts
             if short_name in entities_table:

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -258,7 +258,7 @@ class MatObject(ObjectDescription):
     def add_target_and_index(self, name_cls, sig, signode):
         modname = self.options.get("module", self.env.temp_data.get("mat:module"))
 
-        if self.env.config.matlab_short_links:
+        if self.env.config.matlab_short_links and not name_cls[0] == modname:
             # modname is only used for package names
             # - "target.+package" => "package"
             # - "target" => ""


### PR DESCRIPTION
Please see if you think this is the correct fix for #243. I didn't get a chance to create a test specifically for this issue, but all of the existing tests pass, and it does fix the particular case I encountered.

And let me know if you need me to create a test before you merge this.