### PR TITLE
Parsing: Fix bug property default value parsing.

### DIFF
--- a/tests/test_data/ClassWithPropertyCellValues.m
+++ b/tests/test_data/ClassWithPropertyCellValues.m
@@ -1,0 +1,34 @@
+classdef ClassWithPropertyCellValues
+    % A class with property values initialized with a cell array.
+    % The special thing is the two newlines in the midst of the cell array.
+
+
+    properties
+        fields = {
+            'Level', [], @isnumeric
+            'SingleValues','',                 @(x) isempty(x) || iscell(x) || ischar(x)
+
+
+
+            % Multiple newlines in middle of default value.
+            'Unit', '', @(x) ismember(x,{'mV','dBV','dBSPL','mA/m'})
+            }
+
+    end
+
+    methods
+        function obj = ClassWithPropertyCellValues()
+
+        end
+
+        function level = getLevel(obj)
+            % Return the level
+            level = obj.fields{1};
+        end
+
+        function level = getUnit(obj)
+            % Return the unit
+            level = obj.fields{3};
+        end
+    end
+end

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -117,6 +117,7 @@ def test_module(mod):
         "ClassWithTrailingSemicolons",
         "ClassWithSeperatedComments",
         "ClassWithKeywordsAsFieldnames",
+        "ClassWithPropertyCellValues",
         "arguments",
     }
     assert all_items == expected_items

--- a/tests/test_parse_mfile.py
+++ b/tests/test_parse_mfile.py
@@ -884,5 +884,16 @@ def test_ClassWithNamedAsArguments():
     assert meth.docstring == " Add new argument\n"
 
 
+def test_ClassWithPropertyCellValues():
+    mfile = os.path.join(TESTDATA_ROOT, "ClassWithPropertyCellValues.m")
+    obj = mat_types.MatObject.parse_mfile(
+        mfile, "ClassWithPropertyCellValues", "test_data"
+    )
+    assert obj.name == "ClassWithPropertyCellValues"
+    assert obj.bases == []
+    assert "fields" in obj.properties
+    assert "getLevel" in obj.methods
+
+
 if __name__ == "__main__":
     pytest.main([os.path.abspath(__file__)])


### PR DESCRIPTION
If a class property has a multiline default value, we would end in a infinite loop if there was two or more consecutive newlines.