### PR TITLE
CI: Dev. version of Sphinx requires >= Python 3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
         sphinx-version: ["dev"]
         pygments-version: ["latest"]
     steps:


### PR DESCRIPTION
In https://github.com/sphinx-doc/sphinx/commit/541bf7bc67db3e6752383af22c8d7cc4d1eb652f they dropped support for Python < 3.11 for Sphinx.

Update the tests accordingly.