### PR TITLE
Minor tweaks for cleanliness' sake

### DIFF
--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -9,8 +9,6 @@
 """
 
 from .mat_types import (  # noqa: E401
-    MatModule,
-    MatObject,
     MatFunction,
     MatClass,
     MatProperty,

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -1507,7 +1507,7 @@ class MatAttributeDocumenter(MatClassLevelDocumenter):
                     docstrings[i][j], no_link_state
                 )
                 if not_in_literal_block and docstrings[i][j]:  # also not blank line
-                    if match := p.search(docstrings[i][j]):
+                    if p.search(docstrings[i][j]):
                         docstrings[i][j] = p.sub(
                             f":attr:`{name} <{self.class_object().fullname(self.env)}.{name}>`",
                             docstrings[i][j],

--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -22,7 +22,6 @@ from .mat_types import (  # noqa: E401
     MatApplication,
     entities_table,
     entities_name_map,
-    strip_package_prefix,
     try_get_module_entity_or_default,
 )
 
@@ -36,9 +35,7 @@ import sphinx.util
 from sphinx.locale import _
 from sphinx.pycode import PycodeError
 from sphinx.ext.autodoc import (
-    py_ext_sig_re as mat_ext_sig_re,
     identity,
-    Options,
     ALL,
     INSTANCEATTR,
     members_option,
@@ -49,11 +46,8 @@ from sphinx.ext.autodoc import (
     bool_option,
     Documenter as PyDocumenter,
     ModuleDocumenter as PyModuleDocumenter,
-    FunctionDocumenter as PyFunctionDocumenter,
-    ClassDocumenter as PyClassDocumenter,
     ExceptionDocumenter as PyExceptionDocumenter,
     DataDocumenter as PyDataDocumenter,
-    MethodDocumenter as PyMethodDocumenter,
 )
 
 mat_ext_sig_re = re.compile(

--- a/sphinxcontrib/mat_tree_sitter_parser.py
+++ b/sphinxcontrib/mat_tree_sitter_parser.py
@@ -1,6 +1,6 @@
 from importlib.metadata import version
 import tree_sitter_matlab as tsml
-from tree_sitter import Language, Parser
+from tree_sitter import Language
 import re
 
 # Attribute default dictionary used to give default values for e.g. `Abstract` or `Static` when used without

--- a/sphinxcontrib/mat_tree_sitter_parser.py
+++ b/sphinxcontrib/mat_tree_sitter_parser.py
@@ -839,7 +839,7 @@ class MatClassParser:
                         )
             # After all that if our docstring is empty then we have none
             if docstring.strip() == "":
-                docstring == None
+                docstring = None
             else:
                 pass  # docstring = docstring.rstrip()
 
@@ -897,7 +897,7 @@ class MatClassParser:
                         )
             # After all that if our docstring is empty then we have none
             if docstring.strip() == "":
-                docstring == None
+                docstring = None
             else:
                 pass  # docstring = docstring.rstrip()
 

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -483,8 +483,6 @@ class MatObject(object):
         with open(mfile, "rb") as code_f:
             code = code_f.read()
 
-        full_code = code
-
         # parse the file
         tree_sitter_ver = tuple([int(sec) for sec in version("tree_sitter").split(".")])
         if tree_sitter_ver[1] == 21:

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -10,10 +10,7 @@
 
 from io import open  # for opening files with encoding in Python 2
 import os
-from copy import copy
 import sphinx.util
-from sphinxcontrib.mat_lexer import MatlabLexer
-from pygments.token import Token
 from zipfile import ZipFile
 import xml.etree.ElementTree as ET
 from sphinxcontrib.mat_tree_sitter_parser import (
@@ -22,12 +19,7 @@ from sphinxcontrib.mat_tree_sitter_parser import (
     MatScriptParser,
     ML_LANG,
 )
-import tree_sitter_matlab as tsml
-from tree_sitter import Language, Parser
-import logging
-from pathlib import Path
-import cProfile
-import pstats
+from tree_sitter import Parser
 from importlib.metadata import version
 
 logger = sphinx.util.logging.getLogger("matlab-domain")

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -19,7 +19,7 @@ from docutils.parsers.rst import directives, Directive
 
 from sphinx import addnodes
 from sphinx.roles import XRefRole
-from sphinx.locale import _
+from sphinx.locale import _ as translation
 from sphinx.domains import Domain, ObjType, Index
 from sphinx.directives import ObjectDescription
 from sphinx.util.nodes import make_refnode
@@ -102,7 +102,7 @@ class MatObject(ObjectDescription):
     doc_field_types = [
         TypedField(
             "parameter",
-            label=_("Parameters"),
+            label=translation("Parameters"),
             names=(
                 "param",
                 "parameter",
@@ -118,7 +118,7 @@ class MatObject(ObjectDescription):
         ),
         TypedField(
             "variable",
-            label=_("Variables"),
+            label=translation("Variables"),
             rolename="obj",
             names=("var", "ivar", "cvar"),
             typerolename="obj",
@@ -127,18 +127,23 @@ class MatObject(ObjectDescription):
         ),
         GroupedField(
             "exceptions",
-            label=_("Raises"),
+            label=translation("Raises"),
             rolename="exc",
             names=("raises", "raise", "exception", "except"),
             can_collapse=True,
         ),
         Field(
             "returnvalue",
-            label=_("Returns"),
+            label=translation("Returns"),
             has_arg=False,
             names=("returns", "return"),
         ),
-        Field("returntype", label=_("Return type"), has_arg=False, names=("rtype",)),
+        Field(
+            "returntype",
+            label=translation("Return type"),
+            has_arg=False,
+            names=("rtype",),
+        ),
     ]
 
     def get_signature_prefix(self, sig):
@@ -317,16 +322,16 @@ class MatModulelevel(MatObject):
     def get_index_text(self, modname, name_cls):
         if self.objtype == "function":
             if not modname:
-                return _("%s() (built-in function)") % name_cls[0]
-            return _("%s() (in module %s)") % (name_cls[0], modname)
+                return translation("%s() (built-in function)") % name_cls[0]
+            return translation("%s() (in module %s)") % (name_cls[0], modname)
         elif self.objtype == "data":
             if not modname:
-                return _("%s (built-in variable)") % name_cls[0]
-            return _("%s (in module %s)") % (name_cls[0], modname)
+                return translation("%s (built-in variable)") % name_cls[0]
+            return translation("%s (in module %s)") % (name_cls[0], modname)
         elif self.objtype == "application":
             if not modname:
-                return _("%s (built-in application)") % name_cls[0]
-            return _("%s (in module %s)") % (name_cls[0], modname)
+                return translation("%s (built-in application)") % name_cls[0]
+            return translation("%s (in module %s)") % (name_cls[0], modname)
         else:
             return ""
 
@@ -360,8 +365,8 @@ class MatClasslike(MatObject):
     def get_index_text(self, modname, name_cls):
         if self.objtype == "class":
             if not modname:
-                return _("%s (built-in class)") % name_cls[0]
-            return _("%s (class in %s)") % (name_cls[0], modname)
+                return translation("%s (built-in class)") % name_cls[0]
+            return translation("%s (class in %s)") % (name_cls[0], modname)
         elif self.objtype == "exception":
             return name_cls[0]
         else:
@@ -397,49 +402,61 @@ class MatClassmember(MatObject):
                 clsname, methname = name.rsplit(".", 1)
             except ValueError:
                 if modname:
-                    return _("%s() (in module %s)") % (name, modname)
+                    return translation("%s() (in module %s)") % (name, modname)
                 else:
                     return "%s()" % name
             if modname and add_modules:
-                return _("%s() (%s.%s method)") % (methname, modname, clsname)
+                return translation("%s() (%s.%s method)") % (methname, modname, clsname)
             else:
-                return _("%s() (%s method)") % (methname, clsname)
+                return translation("%s() (%s method)") % (methname, clsname)
         elif self.objtype == "staticmethod":
             try:
                 clsname, methname = name.rsplit(".", 1)
             except ValueError:
                 if modname:
-                    return _("%s() (in module %s)") % (name, modname)
+                    return translation("%s() (in module %s)") % (name, modname)
                 else:
                     return "%s()" % name
             if modname and add_modules:
-                return _("%s() (%s.%s static method)") % (methname, modname, clsname)
+                return translation("%s() (%s.%s static method)") % (
+                    methname,
+                    modname,
+                    clsname,
+                )
             else:
-                return _("%s() (%s static method)") % (methname, clsname)
+                return translation("%s() (%s static method)") % (methname, clsname)
         elif self.objtype == "classmethod":
             try:
                 clsname, methname = name.rsplit(".", 1)
             except ValueError:
                 if modname:
-                    return _("%s() (in module %s)") % (name, modname)
+                    return translation("%s() (in module %s)") % (name, modname)
                 else:
                     return "%s()" % name
             if modname:
-                return _("%s() (%s.%s class method)") % (methname, modname, clsname)
+                return translation("%s() (%s.%s class method)") % (
+                    methname,
+                    modname,
+                    clsname,
+                )
             else:
-                return _("%s() (%s class method)") % (methname, clsname)
+                return translation("%s() (%s class method)") % (methname, clsname)
         elif self.objtype == "attribute":
             try:
                 clsname, attrname = name.rsplit(".", 1)
             except ValueError:
                 if modname:
-                    return _("%s (in module %s)") % (name, modname)
+                    return translation("%s (in module %s)") % (name, modname)
                 else:
                     return name
             if modname and add_modules:
-                return _("%s (%s.%s attribute)") % (attrname, modname, clsname)
+                return translation("%s (%s.%s attribute)") % (
+                    attrname,
+                    modname,
+                    clsname,
+                )
             else:
-                return _("%s (%s attribute)") % (attrname, clsname)
+                return translation("%s (%s attribute)") % (attrname, clsname)
         else:
             return ""
 
@@ -529,7 +546,7 @@ class MatModule(Directive):
             # the platform and synopsis aren't printed; in fact, they are only
             # used in the modindex currently
             ret.append(targetnode)
-            indextext = _("%s (module)") % modname_out
+            indextext = translation("%s (module)") % modname_out
             entry = ("single", indextext, "module-" + modname, "", None)
             inode = addnodes.index(entries=[entry])
             ret.append(inode)
@@ -590,8 +607,8 @@ class MATLABModuleIndex(Index):
     """
 
     name = "modindex"
-    localname = _("MATLAB Module Index")
-    shortname = _("matlab index")
+    localname = translation("MATLAB Module Index")
+    shortname = translation("matlab index")
 
     def generate(self, docnames=None):
         content = {}
@@ -644,7 +661,7 @@ class MATLABModuleIndex(Index):
                 num_toplevels += 1
                 subtype = 0
 
-            qualifier = deprecated and _("Deprecated") or ""
+            qualifier = deprecated and translation("Deprecated") or ""
             entries.append(
                 [
                     stripped + modname_out,
@@ -675,17 +692,17 @@ class MATLABDomain(Domain):
     name = "mat"
     label = "MATLAB"
     object_types = {
-        "function": ObjType(_("function"), "func", "obj"),
-        "data": ObjType(_("data"), "data", "obj"),
-        "class": ObjType(_("class"), "class", "obj"),
-        "exception": ObjType(_("exception"), "exc", "obj"),
-        "method": ObjType(_("method"), "meth", "obj"),
-        "classmethod": ObjType(_("class method"), "meth", "obj"),
-        "staticmethod": ObjType(_("static method"), "meth", "obj"),
-        "attribute": ObjType(_("attribute"), "attr", "obj"),
-        "module": ObjType(_("module"), "mod", "obj"),
-        "script": ObjType(_("script"), "scpt", "obj"),
-        "application": ObjType(_("application"), "app", "obj"),
+        "function": ObjType(translation("function"), "func", "obj"),
+        "data": ObjType(translation("data"), "data", "obj"),
+        "class": ObjType(translation("class"), "class", "obj"),
+        "exception": ObjType(translation("exception"), "exc", "obj"),
+        "method": ObjType(translation("method"), "meth", "obj"),
+        "classmethod": ObjType(translation("class method"), "meth", "obj"),
+        "staticmethod": ObjType(translation("static method"), "meth", "obj"),
+        "attribute": ObjType(translation("attribute"), "attr", "obj"),
+        "module": ObjType(translation("module"), "mod", "obj"),
+        "script": ObjType(translation("script"), "scpt", "obj"),
+        "application": ObjType(translation("application"), "app", "obj"),
     }
 
     directives = {
@@ -832,7 +849,7 @@ class MATLABDomain(Domain):
             if synopsis:
                 title += ": " + synopsis
             if deprecated:
-                title += _(" (deprecated)")
+                title += translation(" (deprecated)")
             if platform:
                 title += " (" + platform + ")"
             return make_refnode(

--- a/sphinxcontrib/matlab.py
+++ b/sphinxcontrib/matlab.py
@@ -936,7 +936,7 @@ def setup(app):
         "mat", "autoapplication", mat_directives.MatlabAutodocDirective
     )
 
-    app.add_autodoc_attrgetter(doc.MatModule, doc.MatModule.getter)
+    app.add_autodoc_attrgetter(mat_types.MatModule, mat_types.MatModule.getter)
     app.add_autodoc_attrgetter(doc.MatClass, doc.MatClass.getter)
 
     return {"parallel_read_safe": False}

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -12,7 +12,6 @@ import pickle
 import sys
 import pytest
 import helper
-from sphinx import addnodes
 from sphinx.testing.fixtures import make_app, test_params  # noqa: F811;
 
 

--- a/tests/test_autodoc_properties.py
+++ b/tests/test_autodoc_properties.py
@@ -14,7 +14,6 @@ import helper
 
 import pytest
 
-from sphinx import addnodes
 from sphinx.testing.fixtures import make_app, test_params  # noqa: F811;
 
 

--- a/tests/test_autodoc_short_links.py
+++ b/tests/test_autodoc_short_links.py
@@ -14,7 +14,6 @@ import helper
 
 import pytest
 
-from sphinx import addnodes
 from sphinx.testing.fixtures import make_app, test_params  # noqa: F811;
 
 

--- a/tests/test_classfolder.py
+++ b/tests/test_classfolder.py
@@ -12,7 +12,6 @@ import pickle
 import sys
 import pytest
 import helper
-from sphinx import addnodes
 from sphinx.testing.fixtures import make_app, test_params  # noqa: F811;
 
 

--- a/tests/test_duplicated_link.py
+++ b/tests/test_duplicated_link.py
@@ -15,8 +15,6 @@ import helper
 
 import pytest
 
-from sphinx import addnodes
-from sphinx import version_info
 from sphinx.testing.fixtures import test_params, make_app
 
 

--- a/tests/test_matlabify.py
+++ b/tests/test_matlabify.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
 from sphinxcontrib import mat_documenters as doc
-from sphinxcontrib.mat_types import entities_table
+from sphinxcontrib.mat_types import entities_table, MatModule, MatObject
 import helper
 import pytest
 
@@ -10,7 +10,7 @@ from sphinx.testing.fixtures import test_params, make_app
 
 rootdir = helper.rootdir(__file__)
 matlab_src_dir = str(rootdir / "test_data")
-doc.MatObject.basedir = matlab_src_dir
+MatObject.basedir = matlab_src_dir
 
 
 @pytest.fixture
@@ -18,21 +18,21 @@ def app(make_app):
     # Create app to setup build environment
     srcdir = rootdir / "test_docs"
     app = make_app(srcdir=srcdir)
-    doc.MatObject.basedir = app.config.matlab_src_dir
+    MatObject.basedir = app.config.matlab_src_dir
     return app
 
 
 @pytest.fixture
 def mod(app):
-    return doc.MatObject.matlabify("test_data")
+    return MatObject.matlabify("test_data")
 
 
 # def test_empty():
-#     assert doc.MatObject.matlabify("") is None
+#     assert MatObject.matlabify("") is None
 
 
 def test_unknown():
-    assert doc.MatObject.matlabify("not_test_data") is None
+    assert MatObject.matlabify("not_test_data") is None
 
 
 def test_script(mod, caplog):
@@ -128,12 +128,12 @@ def test_module(mod):
 
 
 def test_parse_twice(mod):
-    mod2 = doc.MatObject.matlabify("test_data")
+    mod2 = MatObject.matlabify("test_data")
     assert mod == mod2
 
 
 def test_classes(mod):
-    assert isinstance(mod, doc.MatModule)
+    assert isinstance(mod, MatModule)
 
     # test superclass
     cls = mod.getter("ClassInheritHandle")
@@ -247,7 +247,7 @@ def test_submodule_class(mod):
 
 def test_folder_class(mod):
     cls_mod = mod.getter("@ClassFolder")
-    assert isinstance(cls_mod, doc.MatModule)
+    assert isinstance(cls_mod, MatModule)
     cls = cls_mod.getter("ClassFolder")
     assert cls.docstring == "A class in a folder"
     assert cls.attrs == {}
@@ -285,7 +285,7 @@ def test_folder_class(mod):
 
 
 def test_function(mod):
-    assert isinstance(mod, doc.MatModule)
+    assert isinstance(mod, MatModule)
     func = mod.getter("f_example")
     assert isinstance(func, doc.MatFunction)
     assert func.getter("__name__") == "f_example"
@@ -298,7 +298,7 @@ def test_function(mod):
 
 
 def test_function_getter(mod):
-    assert isinstance(mod, doc.MatModule)
+    assert isinstance(mod, MatModule)
     func = mod.getter("f_example")
     assert isinstance(func, doc.MatFunction)
     assert func.getter("__name__") == "f_example"
@@ -310,7 +310,7 @@ def test_function_getter(mod):
 
 
 def test_package_function(mod):
-    assert isinstance(mod, doc.MatModule)
+    assert isinstance(mod, MatModule)
     func = mod.getter("f_example")
     assert isinstance(func, doc.MatFunction)
     assert func.getter("__name__") == "f_example"

--- a/tests/test_module_class_names.py
+++ b/tests/test_module_class_names.py
@@ -12,7 +12,6 @@ import pickle
 import sys
 import pytest
 import helper
-from sphinx import addnodes
 from sphinx.testing.fixtures import make_app, test_params  # noqa: F811;
 
 

--- a/tests/test_no_matlab_src_dir.py
+++ b/tests/test_no_matlab_src_dir.py
@@ -9,13 +9,11 @@
     :license: BSD, see LICENSE for details.
 """
 import pickle
-import os
 import sys
 import helper
 
 import pytest
 
-from sphinx import addnodes
 from sphinx.testing.fixtures import make_app, test_params  # noqa: F811;
 
 

--- a/tests/test_numad.py
+++ b/tests/test_numad.py
@@ -9,13 +9,11 @@
     :license: BSD, see LICENSE for details.
 """
 import pickle
-import os
 import sys
 import helper
 
 import pytest
 
-from sphinx import addnodes
 from sphinx.testing.fixtures import make_app, test_params  # noqa: F811;
 
 

--- a/tests/test_package_links.py
+++ b/tests/test_package_links.py
@@ -9,14 +9,11 @@
     :license: BSD, see LICENSE for details.
 """
 import pickle
-import os
 import sys
 import helper
 
 import pytest
 
-from sphinx import addnodes
-from sphinx import version_info
 from sphinx.testing.fixtures import test_params, make_app
 
 

--- a/tests/test_package_prefix.py
+++ b/tests/test_package_prefix.py
@@ -9,7 +9,6 @@
     :license: BSD, see LICENSE for details.
 """
 import pickle
-import os
 import sys
 import helper
 

--- a/tests/test_pymat.py
+++ b/tests/test_pymat.py
@@ -9,7 +9,6 @@
     :license: BSD, see LICENSE for details.
 """
 import pickle
-import os
 import sys
 import helper
 

--- a/tests/test_pymat_common_root.py
+++ b/tests/test_pymat_common_root.py
@@ -9,7 +9,6 @@
     :license: BSD, see LICENSE for details.
 """
 import pickle
-import os
 import sys
 import helper
 

--- a/tests/test_skipping_module_members.py
+++ b/tests/test_skipping_module_members.py
@@ -9,13 +9,11 @@
     :license: BSD, see LICENSE for details.
 """
 import pickle
-import os
 import sys
 import helper
 
 import pytest
 
-from sphinx import addnodes
 from sphinx.testing.fixtures import make_app, test_params  # noqa: F811;
 
 


### PR DESCRIPTION
There are a handful of features my team would like to see in this extension, so I'm just familiarizing myself with the repository to assess how much work might be required to contribute.  While doing so, I went ahead and took care of some minor cleaning tasks as they were pointed out to me by my editor.

### Notes to Reviewers

I've kept all the commits atomic so it's easy to drop any one of them.  I realize there might be reasons I'm unaware of that explain why things were the way they were.  Feel free to drop/revert any commits you deem undesirable.

### Commits

1. **chore: Remove unused imports** (0f488c291b2255681a5e02c8a450f456fd064e60)
1. **chore: Remove pass-through imports** (4b326bfc1bc19b6cf0719eedea3a95fdaff0567b)

   `MatModule` and `MatObject` were imported, but never used, in the `mat_documenters` module; however, they were passed through to the `matlab` and `test_matlabify` modules.  This is unnecessary and confusing for readers, so this commit removes the imports from `mat_documenters`, and instead imports them directly from `mat_types` where needed.
1. **chore: Remove unused variables** (90d8282bc004a7da6a9058efa36ce147c738a20b)
1. **fix: Remove accidental =** (bf897d119b8af1807681815bcb79ce35fde69694)

   Having `docstring == None` here did effectively nothing (it returned `False`, but nothing was done with that return value).  Given the comment above, it looks like this was just a typo, which this commit fixes.
1. **refactor: Rename _ -> translation** (f042a6b901b902e9fe71f943dfbd4a6b9bd69eb9)

   `sphinx.locale` provides `_` as an alias to `get_translation("sphinx")` for brevity's sake, but using `_` is problematic, because (1) its meaning is opaque to the reader, and (2) it's a common Python practice to use `_` for "throw-away" variables (those that are returned by a function or generator, but are unneeded and won't be used), and doing so will shadow the import (as was the case here in the `clear_doc` method).