### PR TITLE
[MAINT] pin tree-sitter-matlab<1.0.5

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,8 +7,8 @@ on:
   push:
   pull_request:
   schedule:
-    # Run everyday at 06:00 UTC
-    - cron:  '* 6 * * *'
+    # Run on Mondays at 06:00 UTC
+    - cron:  '0 6 * * 1'
 
 jobs:
   test-sphinx-45:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.rst", "r") as f_readme:
 
 requires = [
     "Sphinx>=4.0.0",
-    "tree-sitter-matlab>=1.0.2",
+    "tree-sitter-matlab>=1.0.2,<1.0.5",
     "tree-sitter>=0.21.3,<0.23.0",
 ]
 


### PR DESCRIPTION
- Temporary until the issue is fixed upstream or is fixed on matlabdomain side
- change cron schedule to run tests only once Mondays (to avoid bombarding CI with the same workflow for one hour everyday see https://github.com/sphinx-contrib/matlabdomain/actions/workflows/python-package.yml?query=branch%3Amaster+event%3Aschedule)

<img width="1306" height="779" alt="image" src="https://github.com/user-attachments/assets/7ea3bb7a-35d6-4b5b-8c93-d67a632827d3" />
