### PR TITLE
[FEAT] Implement :inherited-members: option for autoclass

### DIFF
--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -7,7 +7,6 @@ Extend autodoc directives to matlabdomain.
 :license: BSD, see LICENSE for details.
 """
 
-import inspect
 import re
 import traceback
 
@@ -435,9 +434,33 @@ class MatlabDocumenter(PyDocumenter):
                         self.fullname,
                     )
         elif self.options.inherited_members:
-            # safe_getmembers() uses dir() which pulls in members from all
-            # base classes
-            members = inspect.get_members(self.object, attr_getter=self.get_attr)
+            # Collect members from the class and all base classes. inspect has
+            # no get_members function, so walk the __bases__ chain manually
+            # using the MATLAB-aware get_attr. Members defined on the class
+            # itself take precedence over inherited ones.
+            seen = {}
+            # (class, is_documented_class) pairs; the documented class is first
+            classes_to_walk = [(self.object, True)]
+            while classes_to_walk:
+                cls, is_root = classes_to_walk.pop(0)
+                # Constructors of base classes must not appear in the
+                # documented class's constructor block, so skip the method
+                # named after each superclass.
+                ctor_name = self.get_attr(cls, "__name__", None)
+                try:
+                    cls_dict = self.get_attr(cls, "__dict__")
+                except AttributeError:
+                    cls_dict = {}
+                for mname, mval in cls_dict.items():
+                    if not is_root and mname == ctor_name:
+                        continue
+                    if mname not in seen:
+                        seen[mname] = mval
+                bases = self.get_attr(cls, "__bases__", {}).values()
+                classes_to_walk.extend(
+                    (base_obj, False) for base_obj in bases if base_obj is not None
+                )
+            members = list(seen.items())
         else:
             # __dict__ contains only the members directly defined in
             # the class (but get them via getattr anyway, to e.g. get
@@ -1324,6 +1347,8 @@ class MatMethodDocumenter(MatDocstringSignatureMixin, MatClassLevelDocumenter):
 
     def import_object(self):
         ret = MatClassLevelDocumenter.import_object(self)
+        if self.object is None:
+            return False
         if self.object.attrs.get("Static"):
             self.directivetype = "staticmethod"
             # document class and static members before ordinary ones

--- a/sphinxcontrib/mat_types.py
+++ b/sphinxcontrib/mat_types.py
@@ -863,7 +863,15 @@ class MatClass(MatObject):
             objdict.update({en: self.getter(en) for en in self.enumerations})
             return objdict
         else:
-            super().getter(name, *defargs)
+            # Fall back to inherited members so that named lookups (used by
+            # autodoc's :inherited-members:) resolve methods and properties
+            # defined on base classes.
+            for base_obj in self.__bases__.values():
+                if base_obj is not None:
+                    member = base_obj.getter(name, None)
+                    if member is not None:
+                        return member
+            return super().getter(name, *defargs)
 
 
 class MatProperty(MatObject):

--- a/tests/roots/test_inherited_members/+pkg/BaseTable.m
+++ b/tests/roots/test_inherited_members/+pkg/BaseTable.m
@@ -1,0 +1,17 @@
+classdef BaseTable < handle
+    % BaseTable - A base class.
+
+    properties
+        baseProp % A property defined on the base class.
+    end
+
+    methods
+        function obj = BaseTable(x)
+            % BaseTable - Base constructor.
+        end
+
+        function addRow(obj, val)
+            % addRow - Add a row, defined on the base class.
+        end
+    end
+end

--- a/tests/roots/test_inherited_members/+pkg/DerivedTable.m
+++ b/tests/roots/test_inherited_members/+pkg/DerivedTable.m
@@ -1,0 +1,17 @@
+classdef DerivedTable < pkg.BaseTable
+    % DerivedTable - A derived class.
+
+    properties
+        derivedProp % A property defined on the derived class.
+    end
+
+    methods
+        function obj = DerivedTable(y)
+            % DerivedTable - Derived constructor.
+        end
+
+        function ownMethod(obj)
+            % ownMethod - A method defined on the derived class.
+        end
+    end
+end

--- a/tests/roots/test_inherited_members/conf.py
+++ b/tests/roots/test_inherited_members/conf.py
@@ -1,0 +1,6 @@
+import os
+
+matlab_src_dir = os.path.abspath(".")
+extensions = ["sphinx.ext.autodoc", "sphinxcontrib.matlab"]
+primary_domain = "mat"
+nitpicky = True

--- a/tests/roots/test_inherited_members/index.rst
+++ b/tests/roots/test_inherited_members/index.rst
@@ -1,0 +1,18 @@
+Inherited members
+=================
+
+.. currentmodule:: pkg
+
+Without inherited members, only members defined on the class itself appear.
+
+.. autoclass:: DerivedTable
+    :show-inheritance:
+    :members:
+
+With inherited members, members from base classes are documented too, while
+base class constructors are excluded from the constructor summary.
+
+.. autoclass:: DerivedTable
+    :show-inheritance:
+    :members:
+    :inherited-members:

--- a/tests/test_inherited_members.py
+++ b/tests/test_inherited_members.py
@@ -1,0 +1,44 @@
+"""test_inherited_members.
+
+Test the ``:inherited-members:`` option for autoclass.
+
+:copyright: Copyright by the Sphinx team, see AUTHORS.
+:license: BSD, see LICENSE for details.
+"""
+
+import pickle
+
+import pytest
+
+
+@pytest.fixture
+def srcdir(rootdir):
+    return rootdir / "roots" / "test_inherited_members"
+
+
+def test_inherited_members(app):
+    content = pickle.loads((app.doctreedir / "index.doctree").read_bytes())
+    text = content[0].astext()
+
+    # The index documents DerivedTable twice: first without and then with the
+    # :inherited-members: option. Split on the explanatory paragraph that
+    # precedes the second directive to compare the two outputs.
+    before, separator, after = text.partition("With inherited members")
+    assert separator, "expected the second autoclass section to be present"
+
+    # Without :inherited-members:, only members defined on DerivedTable appear.
+    assert "ownMethod()" in before
+    assert "derivedProp" in before
+    assert "addRow(val)" not in before
+    assert "baseProp" not in before
+
+    # With :inherited-members:, members inherited from BaseTable appear
+    # alongside the members defined on DerivedTable.
+    assert "ownMethod()" in after
+    assert "derivedProp" in after
+    assert "addRow(val)" in after
+    assert "baseProp" in after
+
+    # The base class constructor must never be pulled into the documented
+    # class's constructor summary.
+    assert "BaseTable(x)" not in text


### PR DESCRIPTION
## Summary

Implements the `:inherited-members:` option for `autoclass`, which previously raised a fatal error:

```
AttributeError: module 'inspect' has no attribute 'get_members'
```

`get_object_members` called `inspect.get_members`, which does not exist. This replaces it with a manual walk of the `__bases__` chain using the MATLAB-aware `get_attr`, collecting members from the class and all of its base classes.

## Changes

- **`get_object_members`**: walk `__bases__` to gather inherited members. Members defined on the class itself take precedence, and base-class constructors are skipped so they don't appear in the documented class's constructor summary.
- **`MatClass.getter`**: fall back to base classes when resolving a member by name, so autodoc can import each inherited method (also fixes a missing `return` in the fallback branch).
- **`MatMethodDocumenter.import_object`**: guard against a `None` object so an unresolved member is skipped rather than crashing.
- **Test**: new `test_inherited_members` covering both that inherited members are documented and that base-class constructors are excluded.

The full suite passes (138 passed, 4 pre-existing xfailed); the new test fails on `master` without these changes.

Closes #180