### PR TITLE
[FIX] Do not crash on namespaced validators in argument blocks

### DIFF
--- a/sphinxcontrib/mat_tree_sitter_parser.py
+++ b/sphinxcontrib/mat_tree_sitter_parser.py
@@ -369,6 +369,13 @@ class MatFunctionParser:
         attrs = self._parse_attributes(attrs_nodes)
 
         arguments = argblock_match.get("args")
+        # The grammar can fail to produce a (property) node for some arguments,
+        # e.g. a namespaced validator with two or more parts and no size/class
+        # specifier ({a.b.v}); the whole argument is wrapped in an ERROR node
+        # and the "args" capture is None. Skip the block instead of crashing,
+        # mirroring _parse_property_section.
+        if arguments is None:
+            return
 
         # TODO this is almost identical to property parsing.
         #      might be a good idea to extract common code here.

--- a/tests/test_data/f_with_namespaced_validator_argument.m
+++ b/tests/test_data/f_with_namespaced_validator_argument.m
@@ -1,0 +1,5 @@
+function out = f_with_namespaced_validator_argument(a)
+    arguments
+        a {x.y.z}
+    end
+end

--- a/tests/test_mat_types.py
+++ b/tests/test_mat_types.py
@@ -1092,6 +1092,25 @@ def test_f_with_input_argument_block(dir_test_data):
     assert obj.args["a2"]["docstring"] == "another input"
 
 
+def test_f_with_namespaced_validator_argument(dir_test_data):
+    # A namespaced validator with two or more name parts and no size/class
+    # specifier is wrapped in an ERROR node by the grammar, so the argument
+    # block yields no parsed arguments. Parsing must degrade gracefully
+    # instead of crashing (see issue #335).
+    mfile = dir_test_data / "f_with_namespaced_validator_argument.m"
+
+    obj = MatObject.parse_mfile(
+        mfile, "f_with_namespaced_validator_argument", "test_data"
+    )
+
+    assert obj.name == "f_with_namespaced_validator_argument"
+    assert list(obj.retv.keys()) == ["out"]
+    # The argument is still known from the function signature, but the
+    # unparseable argument block contributes no metadata for it.
+    assert list(obj.args.keys()) == ["a"]
+    assert obj.args["a"] == {}
+
+
 def test_f_with_output_argument_block(dir_test_data):
     mfile = dir_test_data / "f_with_output_argument_block.m"
 
@@ -1202,6 +1221,7 @@ def test_module(dir_test_data, mod):
         "f_with_function_variable",
         "f_with_input_argument_block",
         "f_with_output_argument_block",
+        "f_with_namespaced_validator_argument",
         "ClassWithUndocumentedMembers",
         "ClassWithGetterSetter",
         "ClassWithDoubleQuotedString",


### PR DESCRIPTION
## Summary

A function argument validated by a namespaced function with two or more name parts and no size/class specifier crashes the build:

```matlab
function out = f(a)
    arguments
        a {x.y.z}
    end
end
```

```
File "sphinxcontrib/mat_tree_sitter_parser.py", line 375, in _parse_argument_section
    for arg in arguments:
TypeError: 'NoneType' object is not iterable
```

The grammar wraps such an argument in an `ERROR` node, so the argument-block query produces no `(property)` captures and `args` is `None`.

## Change

Guard against the `None` capture in `_parse_argument_section` and skip the block, mirroring the existing guard in `_parse_property_section`. The build completes; the unparseable argument simply contributes no metadata (which is not rendered in function output anyway).

Adds a regression test (`f_with_namespaced_validator_argument`) that crashes without the guard.

## Scope

This is a **robustness fix** — it stops the crash. Correctly *parsing* these validators requires a fix in the `tree-sitter-matlab` grammar itself, so this only refs (does not close) the issue.

Refs #335